### PR TITLE
feat(backend): Refine model namespaces and add DTOs

### DIFF
--- a/Spreeview/CommonLibrary/CommonLibrary.csproj
+++ b/Spreeview/CommonLibrary/CommonLibrary.csproj
@@ -6,8 +6,4 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Folder Include="DataClasses\DTOs\" />
-  </ItemGroup>
-
 </Project>

--- a/Spreeview/CommonLibrary/DataClasses/Entities/Episode.cs
+++ b/Spreeview/CommonLibrary/DataClasses/Entities/Episode.cs
@@ -1,7 +1,0 @@
-﻿namespace CommonLibrary.DataClasses.Entities;
-
-public class Episode
-{
-    public int Id { get; set; }
-    public string Title { get; set; }
-}

--- a/Spreeview/CommonLibrary/DataClasses/Entities/Review.cs
+++ b/Spreeview/CommonLibrary/DataClasses/Entities/Review.cs
@@ -1,7 +1,0 @@
-﻿namespace CommonLibrary.DataClasses.Entities;
-
-public class Review
-{
-    public int Id { get; set; }
-    public int EpisodeId { get; set; }
-}

--- a/Spreeview/CommonLibrary/DataClasses/Entities/User.cs
+++ b/Spreeview/CommonLibrary/DataClasses/Entities/User.cs
@@ -1,7 +1,0 @@
-﻿namespace CommonLibrary.DataClasses.Entities;
-
-public class User
-{
-    public int Id { get; set; }
-    public string Name { get; set; }
-}

--- a/Spreeview/CommonLibrary/DataClasses/EpisodeModel/Episode.cs
+++ b/Spreeview/CommonLibrary/DataClasses/EpisodeModel/Episode.cs
@@ -1,0 +1,7 @@
+﻿namespace CommonLibrary.DataClasses.EpisodeModel;
+
+public class Episode : IEntity
+{
+    public int Id { get; set; }
+    public string Title { get; set; } = null!;
+}

--- a/Spreeview/CommonLibrary/DataClasses/EpisodeModel/EpisodeGetDTO.cs
+++ b/Spreeview/CommonLibrary/DataClasses/EpisodeModel/EpisodeGetDTO.cs
@@ -1,0 +1,8 @@
+﻿namespace CommonLibrary.DataClasses.EpisodeModel
+{
+    internal class EpisodeGetDTO : IGetDTO
+    {
+        public int Id { get; set; }
+        public string Title { get; set; } = null!;
+    }
+}

--- a/Spreeview/CommonLibrary/DataClasses/EpisodeModel/EpisodeInsertDTO.cs
+++ b/Spreeview/CommonLibrary/DataClasses/EpisodeModel/EpisodeInsertDTO.cs
@@ -1,0 +1,7 @@
+﻿namespace CommonLibrary.DataClasses.EpisodeModel
+{
+    internal class EpisodeInsertDTO : IInsertDTO
+    {
+        public string Title { get; set; } = null!;
+    }
+}

--- a/Spreeview/CommonLibrary/DataClasses/EpisodeModel/EpisodeUpdateDTO.cs
+++ b/Spreeview/CommonLibrary/DataClasses/EpisodeModel/EpisodeUpdateDTO.cs
@@ -1,0 +1,7 @@
+﻿namespace CommonLibrary.DataClasses.EpisodeModel
+{
+    internal class EpisodeUpdateDTO : IUpdateDTO
+    {
+        public string Title { get; set; } = null!;
+    }
+}

--- a/Spreeview/CommonLibrary/DataClasses/IEntity.cs
+++ b/Spreeview/CommonLibrary/DataClasses/IEntity.cs
@@ -1,0 +1,7 @@
+﻿namespace CommonLibrary.DataClasses
+{
+    internal interface IEntity
+    {
+        public int Id { get; set; }
+    }
+}

--- a/Spreeview/CommonLibrary/DataClasses/IGetDTO.cs
+++ b/Spreeview/CommonLibrary/DataClasses/IGetDTO.cs
@@ -1,0 +1,7 @@
+﻿namespace CommonLibrary.DataClasses
+{
+    internal interface IGetDTO
+    {
+        public int Id { get; set; }
+    }
+}

--- a/Spreeview/CommonLibrary/DataClasses/IInsertDTO.cs
+++ b/Spreeview/CommonLibrary/DataClasses/IInsertDTO.cs
@@ -1,0 +1,6 @@
+﻿namespace CommonLibrary.DataClasses
+{
+    internal interface IInsertDTO
+    {
+    }
+}

--- a/Spreeview/CommonLibrary/DataClasses/IUpdateDTO.cs
+++ b/Spreeview/CommonLibrary/DataClasses/IUpdateDTO.cs
@@ -1,0 +1,6 @@
+﻿namespace CommonLibrary.DataClasses
+{
+    internal interface IUpdateDTO
+    {
+    }
+}

--- a/Spreeview/CommonLibrary/DataClasses/ReviewModel/Review.cs
+++ b/Spreeview/CommonLibrary/DataClasses/ReviewModel/Review.cs
@@ -1,7 +1,7 @@
 ﻿namespace CommonLibrary.DataClasses.Entities;
 
-public class Series
+public class Review : IEntity
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public int EpisodeId { get; set; }
 }

--- a/Spreeview/CommonLibrary/DataClasses/ReviewModel/ReviewGetDTO.cs
+++ b/Spreeview/CommonLibrary/DataClasses/ReviewModel/ReviewGetDTO.cs
@@ -1,0 +1,8 @@
+﻿namespace CommonLibrary.DataClasses.ReviewModel
+{
+    internal class ReviewGetDTO : IGetDTO
+    {
+        public int Id { get; set; }
+        public int EpisodeId { get; set; }
+    }
+}

--- a/Spreeview/CommonLibrary/DataClasses/ReviewModel/ReviewInsertDTO.cs
+++ b/Spreeview/CommonLibrary/DataClasses/ReviewModel/ReviewInsertDTO.cs
@@ -1,0 +1,7 @@
+﻿namespace CommonLibrary.DataClasses.ReviewModel
+{
+    internal class ReviewInsertDTO : IInsertDTO
+    {
+        public int EpisodeId { get; set; }
+    }
+}

--- a/Spreeview/CommonLibrary/DataClasses/ReviewModel/ReviewUpdateDTO.cs
+++ b/Spreeview/CommonLibrary/DataClasses/ReviewModel/ReviewUpdateDTO.cs
@@ -1,0 +1,7 @@
+﻿namespace CommonLibrary.DataClasses.ReviewModel
+{
+    internal class ReviewUpdateDTO : IUpdateDTO
+    {
+        public int EpisodeId { get; set; }
+    }
+}

--- a/Spreeview/CommonLibrary/DataClasses/SeriesModel/Series.cs
+++ b/Spreeview/CommonLibrary/DataClasses/SeriesModel/Series.cs
@@ -1,0 +1,7 @@
+﻿namespace CommonLibrary.DataClasses.SeriesModel;
+
+public class Series : IEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = null!;
+}

--- a/Spreeview/CommonLibrary/DataClasses/SeriesModel/SeriesGetDTO.cs
+++ b/Spreeview/CommonLibrary/DataClasses/SeriesModel/SeriesGetDTO.cs
@@ -1,0 +1,8 @@
+﻿namespace CommonLibrary.DataClasses.SeriesModel
+{
+    internal class SeriesGetDTO : IGetDTO
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = null!;
+    }
+}

--- a/Spreeview/CommonLibrary/DataClasses/SeriesModel/SeriesInsertDTO.cs
+++ b/Spreeview/CommonLibrary/DataClasses/SeriesModel/SeriesInsertDTO.cs
@@ -1,0 +1,7 @@
+﻿namespace CommonLibrary.DataClasses.SeriesModel
+{
+    internal class SeriesInsertDTO : IInsertDTO
+    {
+        public string Name { get; set; } = null!;
+    }
+}

--- a/Spreeview/CommonLibrary/DataClasses/SeriesModel/SeriesUpdateDTO.cs
+++ b/Spreeview/CommonLibrary/DataClasses/SeriesModel/SeriesUpdateDTO.cs
@@ -1,0 +1,7 @@
+﻿namespace CommonLibrary.DataClasses.SeriesModel
+{
+    internal class SeriesUpdateDTO : IUpdateDTO
+    {
+        public string Name { get; set; } = null!;
+    }
+}

--- a/Spreeview/SpreeviewAPI/Controllers/Implementations/EpisodeController.cs
+++ b/Spreeview/SpreeviewAPI/Controllers/Implementations/EpisodeController.cs
@@ -1,4 +1,4 @@
-﻿using CommonLibrary.DataClasses.Entities;
+﻿using CommonLibrary.DataClasses.EpisodeModel;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using SpreeviewAPI.Controllers.Interfaces;

--- a/Spreeview/SpreeviewAPI/Controllers/Implementations/SeriesController.cs
+++ b/Spreeview/SpreeviewAPI/Controllers/Implementations/SeriesController.cs
@@ -1,4 +1,4 @@
-﻿using CommonLibrary.DataClasses.Entities;
+﻿using CommonLibrary.DataClasses.SeriesModel;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using SpreeviewAPI.Controllers.Interfaces;

--- a/Spreeview/SpreeviewAPI/Controllers/Interfaces/IEpisodeController.cs
+++ b/Spreeview/SpreeviewAPI/Controllers/Interfaces/IEpisodeController.cs
@@ -1,4 +1,4 @@
-﻿using CommonLibrary.DataClasses.Entities;
+﻿using CommonLibrary.DataClasses.EpisodeModel;
 using Microsoft.AspNetCore.Mvc;
 
 namespace SpreeviewAPI.Controllers.Interfaces;

--- a/Spreeview/SpreeviewAPI/Controllers/Interfaces/ISeriesController.cs
+++ b/Spreeview/SpreeviewAPI/Controllers/Interfaces/ISeriesController.cs
@@ -1,4 +1,4 @@
-﻿using CommonLibrary.DataClasses.Entities;
+﻿using CommonLibrary.DataClasses.SeriesModel;
 using Microsoft.AspNetCore.Mvc;
 
 namespace SpreeviewAPI.Controllers.Interfaces;


### PR DESCRIPTION
Add DTOs for Episodes, Reviews, and Series. Update, Get and Insert all have separate DTOs to allow for extensibility in the future. Automapper can potentially be used to easily map DTOs to and from their respective entities.