### PR TITLE
feat(backend): Add automapper to backend project

### DIFF
--- a/Spreeview/CommonLibrary/DataClasses/EpisodeModel/EpisodeGetDTO.cs
+++ b/Spreeview/CommonLibrary/DataClasses/EpisodeModel/EpisodeGetDTO.cs
@@ -1,6 +1,6 @@
 ﻿namespace CommonLibrary.DataClasses.EpisodeModel
 {
-    internal class EpisodeGetDTO : IGetDTO
+    public class EpisodeGetDTO : IGetDTO
     {
         public int Id { get; set; }
         public string Title { get; set; } = null!;

--- a/Spreeview/CommonLibrary/DataClasses/EpisodeModel/EpisodeInsertDTO.cs
+++ b/Spreeview/CommonLibrary/DataClasses/EpisodeModel/EpisodeInsertDTO.cs
@@ -1,6 +1,6 @@
 ﻿namespace CommonLibrary.DataClasses.EpisodeModel
 {
-    internal class EpisodeInsertDTO : IInsertDTO
+    public class EpisodeInsertDTO : IInsertDTO
     {
         public string Title { get; set; } = null!;
     }

--- a/Spreeview/CommonLibrary/DataClasses/EpisodeModel/EpisodeUpdateDTO.cs
+++ b/Spreeview/CommonLibrary/DataClasses/EpisodeModel/EpisodeUpdateDTO.cs
@@ -1,6 +1,6 @@
 ﻿namespace CommonLibrary.DataClasses.EpisodeModel
 {
-    internal class EpisodeUpdateDTO : IUpdateDTO
+    public class EpisodeUpdateDTO : IUpdateDTO
     {
         public string Title { get; set; } = null!;
     }

--- a/Spreeview/CommonLibrary/DataClasses/ReviewModel/ReviewGetDTO.cs
+++ b/Spreeview/CommonLibrary/DataClasses/ReviewModel/ReviewGetDTO.cs
@@ -1,6 +1,6 @@
 ﻿namespace CommonLibrary.DataClasses.ReviewModel
 {
-    internal class ReviewGetDTO : IGetDTO
+    public class ReviewGetDTO : IGetDTO
     {
         public int Id { get; set; }
         public int EpisodeId { get; set; }

--- a/Spreeview/CommonLibrary/DataClasses/ReviewModel/ReviewInsertDTO.cs
+++ b/Spreeview/CommonLibrary/DataClasses/ReviewModel/ReviewInsertDTO.cs
@@ -1,6 +1,6 @@
 ﻿namespace CommonLibrary.DataClasses.ReviewModel
 {
-    internal class ReviewInsertDTO : IInsertDTO
+    public class ReviewInsertDTO : IInsertDTO
     {
         public int EpisodeId { get; set; }
     }

--- a/Spreeview/CommonLibrary/DataClasses/ReviewModel/ReviewUpdateDTO.cs
+++ b/Spreeview/CommonLibrary/DataClasses/ReviewModel/ReviewUpdateDTO.cs
@@ -1,6 +1,6 @@
 ﻿namespace CommonLibrary.DataClasses.ReviewModel
 {
-    internal class ReviewUpdateDTO : IUpdateDTO
+    public class ReviewUpdateDTO : IUpdateDTO
     {
         public int EpisodeId { get; set; }
     }

--- a/Spreeview/CommonLibrary/DataClasses/SeriesModel/SeriesGetDTO.cs
+++ b/Spreeview/CommonLibrary/DataClasses/SeriesModel/SeriesGetDTO.cs
@@ -1,6 +1,6 @@
 ﻿namespace CommonLibrary.DataClasses.SeriesModel
 {
-    internal class SeriesGetDTO : IGetDTO
+    public class SeriesGetDTO : IGetDTO
     {
         public int Id { get; set; }
         public string Name { get; set; } = null!;

--- a/Spreeview/CommonLibrary/DataClasses/SeriesModel/SeriesInsertDTO.cs
+++ b/Spreeview/CommonLibrary/DataClasses/SeriesModel/SeriesInsertDTO.cs
@@ -1,6 +1,6 @@
 ﻿namespace CommonLibrary.DataClasses.SeriesModel
 {
-    internal class SeriesInsertDTO : IInsertDTO
+    public class SeriesInsertDTO : IInsertDTO
     {
         public string Name { get; set; } = null!;
     }

--- a/Spreeview/CommonLibrary/DataClasses/SeriesModel/SeriesUpdateDTO.cs
+++ b/Spreeview/CommonLibrary/DataClasses/SeriesModel/SeriesUpdateDTO.cs
@@ -1,6 +1,6 @@
 ﻿namespace CommonLibrary.DataClasses.SeriesModel
 {
-    internal class SeriesUpdateDTO : IUpdateDTO
+    public class SeriesUpdateDTO : IUpdateDTO
     {
         public string Name { get; set; } = null!;
     }

--- a/Spreeview/SpreeviewAPI/MappingProfiles/ReviewMappingProfile.cs
+++ b/Spreeview/SpreeviewAPI/MappingProfiles/ReviewMappingProfile.cs
@@ -1,0 +1,21 @@
+﻿using AutoMapper;
+using CommonLibrary.DataClasses.Entities;
+using CommonLibrary.DataClasses.ReviewModel;
+
+namespace SpreeviewAPI.MappingProfiles
+{
+    public class ReviewMappingProfile : Profile
+    {
+        public ReviewMappingProfile()
+        {
+            CreateMap<Review, ReviewGetDTO>()
+                .ReverseMap();
+
+            CreateMap<Review, ReviewInsertDTO>()
+                .ReverseMap();
+
+            CreateMap<Review, ReviewUpdateDTO>()
+                .ReverseMap();
+        }
+    }
+}

--- a/Spreeview/SpreeviewAPI/Program.cs
+++ b/Spreeview/SpreeviewAPI/Program.cs
@@ -17,6 +17,8 @@ builder.SetupIdentity();
 builder.Services.AddAuthentication();
 builder.Services.AddAuthorization();
 
+builder.Services.AddAutoMapper(typeof(Program));
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.

--- a/Spreeview/SpreeviewAPI/SpreeviewAPI.csproj
+++ b/Spreeview/SpreeviewAPI/SpreeviewAPI.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.12" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.12" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.12" />


### PR DESCRIPTION
Add automapper to backend project, with an example mapping profile to map Review entities to DTOs (ReviewMappingProfle.cs). We can inject an IMapper instance into our services, and Automapper with apply the profile automatically. We will then be able to call IMapper.Map to map our entities automatically based on that profile.