### PR TITLE
fix: Fix ControllerTests

### DIFF
--- a/Spreeview/SpreeviewTests/ControllerTests/EpisodeControllerTests.cs
+++ b/Spreeview/SpreeviewTests/ControllerTests/EpisodeControllerTests.cs
@@ -1,4 +1,5 @@
-﻿using Moq;
+﻿using AutoMapper;
+using Moq;
 using SpreeviewAPI.Controllers.Implementations;
 using SpreeviewAPI.Services.Interfaces;
 
@@ -7,13 +8,14 @@ namespace SpreeviewTests.ControllerTests;
 public class EpisodeControllerTests
 {
     Mock<IEpisodeService> _mockEpisodeService;
+    Mock<IMapper> _mockMapper;
     EpisodeController episodeController;
 
     [SetUp]
     public void Setup()
     {
         _mockEpisodeService = new Mock<IEpisodeService>();
-        episodeController = new EpisodeController(_mockEpisodeService.Object);
+        episodeController = new EpisodeController(_mockEpisodeService.Object, _mockMapper.Object);
     }
 
     [Test]

--- a/Spreeview/SpreeviewTests/ControllerTests/SeriesControllerTests.cs
+++ b/Spreeview/SpreeviewTests/ControllerTests/SeriesControllerTests.cs
@@ -1,4 +1,5 @@
-﻿using Moq;
+﻿using AutoMapper;
+using Moq;
 using SpreeviewAPI.Controllers.Implementations;
 using SpreeviewAPI.Services.Interfaces;
 
@@ -7,13 +8,14 @@ namespace SpreeviewTests.ControllerTests;
 public class SeriesControllerTests
 {
     Mock<ISeriesService> _mockSeriesService;
+    Mock<IMapper> _mockMapper;
     SeriesController seriesController;
 
     [SetUp]
     public void Setup()
     {
         _mockSeriesService = new Mock<ISeriesService>();
-        seriesController = new SeriesController(_mockSeriesService.Object);
+        seriesController = new SeriesController(_mockSeriesService.Object, _mockMapper.Object);
     }
 
     [Test]


### PR DESCRIPTION
EpisodeController and SeriesController require an IMapper instance in their constructors. Mock these and inject them during test setups.