### PR TITLE
Add endpoint tests, add HTTP call utility class

### DIFF
--- a/Spreeview/SpreeviewAPI/Controllers/Implementations/SeasonController.cs
+++ b/Spreeview/SpreeviewAPI/Controllers/Implementations/SeasonController.cs
@@ -22,7 +22,7 @@ public class SeasonController : ControllerBase, ISeasonController
 	public async Task<ActionResult> GetSeasonByIds(int seriesId, int seasonNumber)
 	{
 		var response = await _seasonService.FindSeasonByIds(seriesId, seasonNumber);
-		if (response == null) return NotFound();
+		if (response == null) return NotFound("There is no season with the associated values.");
 		SeasonGetDTO mappedSeasonDTO = _seasonMapper.Map<SeasonGetDTO>(response);
 		return Ok(mappedSeasonDTO);
 	}

--- a/Spreeview/SpreeviewAPI/Controllers/Implementations/SeriesController.cs
+++ b/Spreeview/SpreeviewAPI/Controllers/Implementations/SeriesController.cs
@@ -19,16 +19,16 @@ public class SeriesController : ControllerBase, ISeriesController
     }
 
     [HttpGet("trending")]
-    public async Task<ActionResult> IndexPopular()
+    public async Task<ActionResult> IndexPopularSeries()
     {
         var response = await _seriesService.IndexPopularSeries();
-        if (response == null) return NotFound();
+        if (response == null) return NotFound("There were no popular series found.");
         var dtoList = _mapper.Map<List<SeriesGetDTO>>(response);
         return Ok(dtoList);
     }
 
     [HttpGet("top")]
-    public async Task<ActionResult> IndexTopRated()
+    public async Task<ActionResult> IndexTopRatedSeries()
     {
         var response = await _seriesService.IndexTopRatedSeries();
         if (response == null) return NotFound("There were no top-rated series found.");
@@ -37,17 +37,18 @@ public class SeriesController : ControllerBase, ISeriesController
     }
 
     [HttpGet("{id:int}")]
-    public async Task<ActionResult> GetById(int id)
+    public async Task<ActionResult> GetSeriesById(int seriesId)
     {
-        var response = await _seriesService.FindSeriesById(id);
-        if (response == null) return NotFound();
+        var response = await _seriesService.FindSeriesById(seriesId);
+        if (response == null) return NotFound("There is no series with the associated ID.");
         var dto = _mapper.Map<SeriesGetDTO>(response);
         return Ok(dto);
     }
 
     [HttpGet("search")]
-    public async Task<ActionResult> GetByKeywords([FromQuery] string query)
+    public async Task<ActionResult> GetSeriesByKeywords([FromQuery] string query)
     {
+        if (String.IsNullOrWhiteSpace(query)) return BadRequest("Please enter a valid query.");
         List<Series>? response = await _seriesService.FindSeriesByKeywords(query);
         if (response == null) return NotFound("There were no series found from the given query.");
         List<SeriesGetDTO> dtoList = _mapper.Map<List<SeriesGetDTO>>(response);

--- a/Spreeview/SpreeviewAPI/Controllers/Implementations/SeriesController.cs
+++ b/Spreeview/SpreeviewAPI/Controllers/Implementations/SeriesController.cs
@@ -36,7 +36,7 @@ public class SeriesController : ControllerBase, ISeriesController
         return Ok(dtoList);
     }
 
-    [HttpGet("{id:int}")]
+    [HttpGet("{seriesId:int}")]
     public async Task<ActionResult> GetSeriesById(int seriesId)
     {
         var response = await _seriesService.FindSeriesById(seriesId);

--- a/Spreeview/SpreeviewAPI/Controllers/Implementations/SeriesController.cs
+++ b/Spreeview/SpreeviewAPI/Controllers/Implementations/SeriesController.cs
@@ -21,7 +21,7 @@ public class SeriesController : ControllerBase, ISeriesController
     [HttpGet("trending")]
     public async Task<ActionResult> IndexPopular()
     {
-        var response = await _seriesService.IndexPopular();
+        var response = await _seriesService.IndexPopularSeries();
         if (response == null) return NotFound();
         var dtoList = _mapper.Map<List<SeriesGetDTO>>(response);
         return Ok(dtoList);
@@ -30,8 +30,8 @@ public class SeriesController : ControllerBase, ISeriesController
     [HttpGet("top")]
     public async Task<ActionResult> IndexTopRated()
     {
-        var response = await _seriesService.IndexTopRated();
-        if (response == null) return NotFound();
+        var response = await _seriesService.IndexTopRatedSeries();
+        if (response == null) return NotFound("There were no top-rated series found.");
         List<SeriesGetDTO> dtoList = _mapper.Map<List<SeriesGetDTO>>(response);
         return Ok(dtoList);
     }
@@ -39,7 +39,7 @@ public class SeriesController : ControllerBase, ISeriesController
     [HttpGet("{id:int}")]
     public async Task<ActionResult> GetById(int id)
     {
-        var response = await _seriesService.GetById(id);
+        var response = await _seriesService.FindSeriesById(id);
         if (response == null) return NotFound();
         var dto = _mapper.Map<SeriesGetDTO>(response);
         return Ok(dto);
@@ -48,8 +48,8 @@ public class SeriesController : ControllerBase, ISeriesController
     [HttpGet("search")]
     public async Task<ActionResult> GetByKeywords([FromQuery] string query)
     {
-        List<Series>? response = await _seriesService.FindByKeywords(query);
-        if (response == null) return NotFound();
+        List<Series>? response = await _seriesService.FindSeriesByKeywords(query);
+        if (response == null) return NotFound("There were no series found from the given query.");
         List<SeriesGetDTO> dtoList = _mapper.Map<List<SeriesGetDTO>>(response);
         return Ok(dtoList);
     }
@@ -58,7 +58,7 @@ public class SeriesController : ControllerBase, ISeriesController
     public async Task<ActionResult> GetRecommendationsById(int seriesId)
     {
         List<Series>? response = await _seriesService.FindRecommendationsById(seriesId);
-        if (response == null) return NotFound();
+        if (response == null) return NotFound("There were no recommendations found for the given series ID.");
         List<SeriesGetDTO> dtoList = _mapper.Map<List<SeriesGetDTO>>(response);
         return Ok(dtoList);
     }

--- a/Spreeview/SpreeviewAPI/Controllers/Interfaces/ISeriesController.cs
+++ b/Spreeview/SpreeviewAPI/Controllers/Interfaces/ISeriesController.cs
@@ -4,9 +4,9 @@ namespace SpreeviewAPI.Controllers.Interfaces;
 
 public interface ISeriesController
 {
-    Task<ActionResult> IndexPopular();
-    Task<ActionResult> IndexTopRated();
-    Task<ActionResult> GetById(int id);
-    Task<ActionResult> GetByKeywords(string query);
+    Task<ActionResult> IndexPopularSeries();
+    Task<ActionResult> IndexTopRatedSeries();
+    Task<ActionResult> GetSeriesById(int seriesId);
+    Task<ActionResult> GetSeriesByKeywords(string query);
     Task<ActionResult> GetRecommendationsById(int seriesId);
 }

--- a/Spreeview/SpreeviewAPI/Program.cs
+++ b/Spreeview/SpreeviewAPI/Program.cs
@@ -1,8 +1,8 @@
 using Microsoft.AspNetCore.Identity;
 using SpreeviewAPI;
-using SpreeviewAPI.Database;
 using SpreeviewAPI.Services.Implementations;
 using SpreeviewAPI.Services.Interfaces;
+using SpreeviewAPI.Utilities;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -13,6 +13,7 @@ builder.Services.AddScoped<IEpisodeService, EpisodeService>();
 builder.Services.AddScoped<IReviewService, ReviewService>();
 builder.Services.AddScoped<ISeriesService, SeriesService>();
 builder.Services.AddScoped<ISeasonService, SeasonService>();
+builder.Services.AddScoped<IRequestManager, RequestManager>();
 
 string tmdbAccessToken = builder.Configuration["HttpClient:BearerToken"]!;
 

--- a/Spreeview/SpreeviewAPI/Services/Implementations/EpisodeService.cs
+++ b/Spreeview/SpreeviewAPI/Services/Implementations/EpisodeService.cs
@@ -1,36 +1,21 @@
 ﻿using CommonLibrary.DataClasses.EpisodeModel;
 using SpreeviewAPI.Services.Interfaces;
+using SpreeviewAPI.Utilities;
 
 namespace SpreeviewAPI.Services.Implementations;
 
 public class EpisodeService : IEpisodeService
 {
-    private readonly IHttpClientFactory _httpClientFactory;
-    public EpisodeService(IHttpClientFactory httpClientFactory)
+    private readonly IRequestManager _requestManager;
+    public EpisodeService(IRequestManager requestManager)
     {
-        _httpClientFactory = httpClientFactory;
+        _requestManager = requestManager;
     }
 
     public async Task<Episode?> FindEpisodeByIds(int seriesId, int seasonNumber, int episodeNumber)
     {
-        HttpClient client;
-        Episode? returnedEpisode;
-
         string urlSuffix = $"tv/{seriesId}/season/{seasonNumber}/episode/{episodeNumber}";
-
-        try
-        {
-            using (client = _httpClientFactory.CreateClient("tmdb"))
-            {
-                returnedEpisode = await client.GetFromJsonAsync<Episode>(urlSuffix);
-            }
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine("An error has occured: ", ex.Message);
-            returnedEpisode = null;
-        }
-
+        Episode? returnedEpisode = await _requestManager.TmdbGetAsync<Episode>(urlSuffix);
         return returnedEpisode;
     }
 }

--- a/Spreeview/SpreeviewAPI/Services/Implementations/SeasonService.cs
+++ b/Spreeview/SpreeviewAPI/Services/Implementations/SeasonService.cs
@@ -1,38 +1,21 @@
 ﻿using CommonLibrary.DataClasses.SeasonModel;
 using SpreeviewAPI.Services.Interfaces;
+using SpreeviewAPI.Utilities;
 
-namespace SpreeviewAPI.Services.Implementations
+namespace SpreeviewAPI.Services.Implementations;
+
+public class SeasonService : ISeasonService
 {
-    public class SeasonService : ISeasonService
+    private readonly IRequestManager _requestManager;
+    public SeasonService(IRequestManager requestManager)
+    {
+        _requestManager = requestManager;
+    }
+
+	public async Task<Season?> FindSeasonByIds(int seriesId, int seasonNumber)
 	{
-		private readonly IHttpClientFactory _httpClientFactory;
-
-		public SeasonService(IHttpClientFactory httpClientFactory)
-		{
-			_httpClientFactory = httpClientFactory;
-		}
-
-		public async virtual Task<Season?> FindSeasonByIds(int seriesId, int seasonNumber)
-		{
-			HttpClient client;
-			Season? returnedSeason;
-
-			string urlSuffix = $"tv/{seriesId}/season/{seasonNumber}";
-
-			try
-			{
-				using (client = _httpClientFactory.CreateClient("tmdb"))
-				{
-					returnedSeason = await client.GetFromJsonAsync<Season>(urlSuffix);
-				}
-			}
-			catch (Exception ex)
-			{
-				Console.WriteLine($"An error occurred: {ex.Message}");
-				returnedSeason = null;
-			}
-
-			return returnedSeason;
-		}
+		string urlSuffix = $"tv/{seriesId}/season/{seasonNumber}";
+		Season? returnedSeason = await _requestManager.TmdbGetAsync<Season>(urlSuffix);
+		return returnedSeason;
 	}
 }

--- a/Spreeview/SpreeviewAPI/Services/Implementations/SeriesService.cs
+++ b/Spreeview/SpreeviewAPI/Services/Implementations/SeriesService.cs
@@ -1,97 +1,74 @@
 ﻿using CommonLibrary.DataClasses.SeriesModel;
 using SpreeviewAPI.Services.Interfaces;
+using SpreeviewAPI.Utilities;
 using SpreeviewAPI.Wrappers;
 
 namespace SpreeviewAPI.Services.Implementations;
 
-public class SeriesService(IHttpClientFactory httpClientFactory) : ISeriesService
+public class SeriesService: ISeriesService
 {
-    public async Task<IEnumerable<Series>?> IndexPopular()
+    private readonly IRequestManager _requestManager;
+    public SeriesService(IRequestManager requestManager)
+    {
+        _requestManager = requestManager;
+    }
+
+    public async Task<List<Series>?> IndexPopularSeries()
     {
         const string urlSuffix = $"trending/tv/week";
-        SeriesResponse? seriesResponse;
-        try
-        {
-            using var httpClient = httpClientFactory.CreateClient("tmdb");
-            seriesResponse = await httpClient.GetFromJsonAsync<SeriesResponse>(urlSuffix);
-        }
-        catch (Exception e)
-        {
-            return null;
-        }
-        return seriesResponse?.Results;
+        List<Series>? returnedSeriesList = null;
+
+        SeriesResponse? returnedResponse = await _requestManager.TmdbGetAsync<SeriesResponse>(urlSuffix);
+
+        if (returnedResponse != null)
+            returnedSeriesList = returnedResponse.Results;
+
+        return returnedSeriesList;
     }
 
-    public async Task<List<Series>?> IndexTopRated()
+    public async Task<List<Series>?> IndexTopRatedSeries()
     {
         const string urlSuffix = $"tv/top_rated";
-        SeriesResponse? seriesResponse;
+        List<Series>? returnedSeriesList = null;
 
-        try
-        {
-            using var httpClient = httpClientFactory.CreateClient("tmdb");
-            seriesResponse = await httpClient.GetFromJsonAsync<SeriesResponse>(urlSuffix);
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine("An error has occured: ", ex.Message);
-            return null;
-        }
+        SeriesResponse? returnedResponse = await _requestManager.TmdbGetAsync<SeriesResponse>(urlSuffix);
 
-        return seriesResponse?.Results;
+        if (returnedResponse != null)
+            returnedSeriesList = returnedResponse.Results;
+
+        return returnedSeriesList;
     }
 
-    public async Task<Series?> GetById(int id)
+    public async Task<Series?> FindSeriesById(int id)
     {
         var urlSuffix = $"tv/{id}";
-        Series? returnedSeries;
-        try
-        {
-            using var client = httpClientFactory.CreateClient("tmdb");
-            returnedSeries = await client.GetFromJsonAsync<Series>(urlSuffix);
-        }
-        catch (Exception ex)
-        {
-            returnedSeries = null;
-        }
+        Series? returnedSeries = await _requestManager.TmdbGetAsync<Series>(urlSuffix);
         return returnedSeries;
     }
 
-    public async Task<List<Series>?> FindByKeywords(string query)
+    public async Task<List<Series>?> FindSeriesByKeywords(string query)
     {
         string urlSuffix = $"search/tv?query={query}";
-        SeriesResponse? seriesResponse;
+        List<Series>? returnedSeriesList = null;
 
-        try
-        {
-            using var httpClient = httpClientFactory.CreateClient("tmdb");
-            seriesResponse = await httpClient.GetFromJsonAsync<SeriesResponse>(urlSuffix);
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine("An error has occurred: ", ex.Message);
-            seriesResponse = null;
-        }
+        SeriesResponse? returnedResponse = await _requestManager.TmdbGetAsync<SeriesResponse>(urlSuffix);
 
-        return seriesResponse?.Results;
+        if (returnedResponse != null)
+            returnedSeriesList = returnedResponse.Results;
+
+        return returnedSeriesList;
     }
 
     public async Task<List<Series>?> FindRecommendationsById(int seriesId)
     {
         string urlSuffix = $"tv/{seriesId}/recommendations";
-        SeriesResponse? seriesResponse;
+        List<Series>? returnedSeriesList = null;
 
-        try
-        {
-            using var httpClient = httpClientFactory.CreateClient("tmdb");
-            seriesResponse = await httpClient.GetFromJsonAsync<SeriesResponse>(urlSuffix);
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine("An error has occurred: ", ex.Message);
-            seriesResponse = null;
-        }
+        SeriesResponse? returnedResponse = await _requestManager.TmdbGetAsync<SeriesResponse>(urlSuffix);
 
-        return seriesResponse?.Results;
+        if (returnedResponse != null)
+            returnedSeriesList = returnedResponse.Results;
+
+        return returnedSeriesList;
     }
 }

--- a/Spreeview/SpreeviewAPI/Services/Implementations/SeriesService.cs
+++ b/Spreeview/SpreeviewAPI/Services/Implementations/SeriesService.cs
@@ -39,9 +39,9 @@ public class SeriesService: ISeriesService
         return returnedSeriesList;
     }
 
-    public async Task<Series?> FindSeriesById(int id)
+    public async Task<Series?> FindSeriesById(int seriesId)
     {
-        var urlSuffix = $"tv/{id}";
+        var urlSuffix = $"tv/{seriesId}";
         Series? returnedSeries = await _requestManager.TmdbGetAsync<Series>(urlSuffix);
         return returnedSeries;
     }

--- a/Spreeview/SpreeviewAPI/Services/Interfaces/ISeriesService.cs
+++ b/Spreeview/SpreeviewAPI/Services/Interfaces/ISeriesService.cs
@@ -6,7 +6,7 @@ public interface ISeriesService
 {
     Task<List<Series>?> IndexPopularSeries();
     Task<List<Series>?> IndexTopRatedSeries();
-    Task<Series?> FindSeriesById(int id);
+    Task<Series?> FindSeriesById(int seriesId);
     Task<List<Series>?> FindSeriesByKeywords(string query);
     Task<List<Series>?> FindRecommendationsById(int seriesId);
 }

--- a/Spreeview/SpreeviewAPI/Services/Interfaces/ISeriesService.cs
+++ b/Spreeview/SpreeviewAPI/Services/Interfaces/ISeriesService.cs
@@ -4,9 +4,9 @@ namespace SpreeviewAPI.Services.Interfaces;
 
 public interface ISeriesService
 {
-    Task<IEnumerable<Series>?> IndexPopular();
-    Task<List<Series>?> IndexTopRated();
-    Task<Series?> GetById(int id);
-    Task<List<Series>?> FindByKeywords(string query);
+    Task<List<Series>?> IndexPopularSeries();
+    Task<List<Series>?> IndexTopRatedSeries();
+    Task<Series?> FindSeriesById(int id);
+    Task<List<Series>?> FindSeriesByKeywords(string query);
     Task<List<Series>?> FindRecommendationsById(int seriesId);
 }

--- a/Spreeview/SpreeviewAPI/Utilities/IRequestManager.cs
+++ b/Spreeview/SpreeviewAPI/Utilities/IRequestManager.cs
@@ -1,0 +1,7 @@
+﻿
+namespace SpreeviewAPI.Utilities;
+
+public interface IRequestManager
+{
+    Task<T?> TmdbGetAsync<T>(string urlSuffix);
+}

--- a/Spreeview/SpreeviewAPI/Utilities/RequestManager.cs
+++ b/Spreeview/SpreeviewAPI/Utilities/RequestManager.cs
@@ -1,0 +1,31 @@
+﻿namespace SpreeviewAPI.Utilities;
+
+public class RequestManager : IRequestManager
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    public RequestManager(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public async Task<T?> TmdbGetAsync<T>(string urlSuffix)
+    {
+        HttpClient httpClient;
+        T? responseValue;
+
+        try
+        {
+            using (httpClient = _httpClientFactory.CreateClient("tmdb"))
+            {
+                responseValue = await httpClient.GetFromJsonAsync<T>(urlSuffix);
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"An error has occured: {ex.Message}");
+            responseValue = default(T);
+        }
+
+        return responseValue;
+    }
+}

--- a/Spreeview/SpreeviewTests/ControllerTests/EpisodeControllerTests.cs
+++ b/Spreeview/SpreeviewTests/ControllerTests/EpisodeControllerTests.cs
@@ -1,6 +1,9 @@
 ﻿using AutoMapper;
+using CommonLibrary.DataClasses.EpisodeModel;
+using Microsoft.AspNetCore.Mvc;
 using Moq;
 using SpreeviewAPI.Controllers.Implementations;
+using SpreeviewAPI.MappingProfiles;
 using SpreeviewAPI.Services.Interfaces;
 
 namespace SpreeviewTests.ControllerTests;
@@ -8,19 +11,110 @@ namespace SpreeviewTests.ControllerTests;
 public class EpisodeControllerTests
 {
     Mock<IEpisodeService> _mockEpisodeService;
-    Mock<IMapper> _mockMapper;
+
+    EpisodeMappingProfile episodeMappingProfile;
+    MapperConfiguration episodeMappingConfig;
+    Mapper _mapper;
+
     EpisodeController episodeController;
 
     [SetUp]
     public void Setup()
     {
         _mockEpisodeService = new Mock<IEpisodeService>();
-        episodeController = new EpisodeController(_mockEpisodeService.Object, _mockMapper.Object);
+
+        episodeMappingProfile = new EpisodeMappingProfile();
+        episodeMappingConfig = new MapperConfiguration(config => config.AddProfile(episodeMappingProfile));
+        _mapper = new Mapper(episodeMappingConfig);
+
+        episodeController = new EpisodeController(_mockEpisodeService.Object, _mapper);
+    }
+
+    #region GetEpisodeByIds method tests
+    [Test]
+    public async Task GetEpisodeByIds_CallsServiceMethodOnce()
+    {
+        // Arrange
+        int testSeriesId = 1;
+        int testSeasonNum = 2;
+        int testEpisodeNum = 3;
+
+        Episode expectedServiceReturn = new Episode() { Id = 1, Title = "TestEpisode" };
+
+        _mockEpisodeService.Setup(mock => mock.FindEpisodeByIds(testSeriesId, testSeasonNum, testEpisodeNum))
+                           .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        await episodeController.GetEpisodeByIds(testSeriesId, testSeasonNum, testEpisodeNum);
+
+        // Assert
+        _mockEpisodeService.Verify(mock => mock.FindEpisodeByIds(testSeriesId, testSeasonNum, testEpisodeNum), Times.Once());
     }
 
     [Test]
-    public void GetEpisodeById_DoesSomething()
+    public async Task GetEpisodeByIds_OnValidRequest_ReturnsOkObjectResult()
     {
-        Assert.Pass();
+        // Arrange
+        int testSeriesId = 1;
+        int testSeasonNum = 2;
+        int testEpisodeNum = 3;
+
+        Episode expectedServiceReturn = new Episode() { Id = 1, Title = "TestEpisode" };
+
+        _mockEpisodeService.Setup(mock => mock.FindEpisodeByIds(testSeriesId, testSeasonNum, testEpisodeNum))
+                           .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        var resultObject = await episodeController.GetEpisodeByIds(testSeriesId, testSeasonNum, testEpisodeNum);
+
+        // Assert
+        Assert.That(resultObject, Is.TypeOf<OkObjectResult>());
     }
+
+    [Test]
+    public async Task GetEpisodeByIds_OnValidRequest_ReturnsMappedEpisode()
+    {
+        // Arrange
+        int testSeriesId = 1;
+        int testSeasonNum = 2;
+        int testEpisodeNum = 3;
+
+        Episode expectedServiceReturn = new Episode() { Id = 1, Title = "TestEpisode" };
+        EpisodeGetDTO expectedControllerReturn = new EpisodeGetDTO() { Id = 1, Title = "TestEpisode" };
+
+        _mockEpisodeService.Setup(mock => mock.FindEpisodeByIds(testSeriesId, testSeasonNum, testEpisodeNum))
+                           .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        var resultObject = await episodeController.GetEpisodeByIds(testSeriesId, testSeasonNum, testEpisodeNum) as OkObjectResult;
+        var resultValue = resultObject!.Value as EpisodeGetDTO;
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(resultValue!.Id, Is.EqualTo(expectedControllerReturn.Id));
+            Assert.That(resultValue.Title, Is.EqualTo(expectedControllerReturn.Title));
+        });
+    }
+
+    [Test]
+    public async Task GetEpisodeByIds_OnInvalidRequest_ReturnsNotFoundObjectResult()
+    {
+        // Arrange
+        int testSeriesId = int.MaxValue;
+        int testSeasonNum = int.MaxValue;
+        int testEpisodeNum = int.MaxValue;
+
+        Episode? expectedServiceReturn = null;
+
+        _mockEpisodeService.Setup(mock => mock.FindEpisodeByIds(testSeriesId, testSeasonNum, testEpisodeNum))
+                           .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        var resultObject = await episodeController.GetEpisodeByIds(testSeriesId, testSeasonNum, testEpisodeNum);
+
+        // Assert
+        Assert.That(resultObject, Is.TypeOf<NotFoundObjectResult>());
+    }
+    #endregion
 }

--- a/Spreeview/SpreeviewTests/ControllerTests/SeasonControllerTests.cs
+++ b/Spreeview/SpreeviewTests/ControllerTests/SeasonControllerTests.cs
@@ -1,0 +1,116 @@
+﻿using AutoMapper;
+using CommonLibrary.DataClasses.SeasonModel;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using SpreeviewAPI.Controllers.Implementations;
+using SpreeviewAPI.MappingProfiles;
+using SpreeviewAPI.Services.Interfaces;
+
+namespace SpreeviewTests.ControllerTests;
+
+public class SeasonControllerTests
+{
+    Mock<ISeasonService> _mockSeasonService;
+
+    SeasonMappingProfile seasonMappingProfile;
+    MapperConfiguration seasonMappingConfig;
+    Mapper _mapper;
+
+    SeasonController seasonController;
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockSeasonService = new Mock<ISeasonService>();
+
+        seasonMappingProfile = new SeasonMappingProfile();
+        seasonMappingConfig = new MapperConfiguration(config => config.AddProfile(seasonMappingProfile));
+        _mapper = new Mapper(seasonMappingConfig);
+
+        seasonController = new SeasonController(_mockSeasonService.Object, _mapper);
+    }
+
+    #region GetSeasonByIds method tests
+    [Test]
+    public async Task GetSeasonByIds_CallsServiceMethodOnce()
+    {
+        // Arrange
+        int testSeriesId = 1;
+        int testSeasonNum = 2;
+
+        Season expectedServiceReturn = new Season() { Id = 1, SeasonNumber = 2 };
+
+        _mockSeasonService.Setup(mock => mock.FindSeasonByIds(testSeriesId, testSeasonNum))
+                           .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        await seasonController.GetSeasonByIds(testSeriesId, testSeasonNum);
+
+        // Assert
+        _mockSeasonService.Verify(mock => mock.FindSeasonByIds(testSeriesId, testSeasonNum), Times.Once());
+    }
+
+    [Test]
+    public async Task GetSeasonByIds_OnValidRequest_ReturnsOkObjectResult()
+    {
+        // Arrange
+        int testSeriesId = 1;
+        int testSeasonNum = 2;
+
+        Season expectedServiceReturn = new Season() { Id = 1, SeasonNumber = 2 };
+
+        _mockSeasonService.Setup(mock => mock.FindSeasonByIds(testSeriesId, testSeasonNum))
+                           .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        var resultObject = await seasonController.GetSeasonByIds(testSeriesId, testSeasonNum);
+
+        // Assert
+        Assert.That(resultObject, Is.TypeOf<OkObjectResult>());
+    }
+
+    [Test]
+    public async Task GetSeasonByIds_OnValidRequest_ReturnsMappedSeason()
+    {
+        // Arrange
+        int testSeriesId = 1;
+        int testSeasonNum = 2;
+
+        Season expectedServiceReturn = new Season() { Id = 1, SeasonNumber = 2 };
+        SeasonGetDTO expectedControllerReturn = new SeasonGetDTO() { Id = 1, SeasonNumber = 2 };
+
+        _mockSeasonService.Setup(mock => mock.FindSeasonByIds(testSeriesId, testSeasonNum))
+                           .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        var resultObject = await seasonController.GetSeasonByIds(testSeriesId, testSeasonNum) as OkObjectResult;
+        var resultValue = resultObject!.Value as SeasonGetDTO;
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(resultValue!.Id, Is.EqualTo(expectedControllerReturn.Id));
+            Assert.That(resultValue.SeasonNumber, Is.EqualTo(expectedControllerReturn.SeasonNumber));
+        });
+    }
+
+    [Test]
+    public async Task GetSeasonByIds_OnInvalidRequest_ReturnsNotFoundObjectResult()
+    {
+        // Arrange
+        int testSeriesId = int.MaxValue;
+        int testSeasonNum = int.MaxValue;
+
+        Season? expectedServiceReturn = null;
+
+        _mockSeasonService.Setup(mock => mock.FindSeasonByIds(testSeriesId, testSeasonNum))
+                           .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        var resultObject = await seasonController.GetSeasonByIds(testSeriesId, testSeasonNum);
+
+        // Assert
+        Assert.That(resultObject, Is.TypeOf<NotFoundObjectResult>());
+    }
+    #endregion
+}

--- a/Spreeview/SpreeviewTests/ControllerTests/SeriesControllerTests.cs
+++ b/Spreeview/SpreeviewTests/ControllerTests/SeriesControllerTests.cs
@@ -1,6 +1,9 @@
 ﻿using AutoMapper;
+using CommonLibrary.DataClasses.SeriesModel;
+using Microsoft.AspNetCore.Mvc;
 using Moq;
 using SpreeviewAPI.Controllers.Implementations;
+using SpreeviewAPI.MappingProfiles;
 using SpreeviewAPI.Services.Interfaces;
 
 namespace SpreeviewTests.ControllerTests;
@@ -8,19 +11,479 @@ namespace SpreeviewTests.ControllerTests;
 public class SeriesControllerTests
 {
     Mock<ISeriesService> _mockSeriesService;
-    Mock<IMapper> _mockMapper;
+
+    SeriesMappingProfile seriesMappingProfile;
+    MapperConfiguration seriesMappingConfig;
+    Mapper _mapper;
+
     SeriesController seriesController;
 
     [SetUp]
     public void Setup()
     {
         _mockSeriesService = new Mock<ISeriesService>();
-        seriesController = new SeriesController(_mockSeriesService.Object, _mockMapper.Object);
+
+        seriesMappingProfile = new SeriesMappingProfile();
+        seriesMappingConfig = new MapperConfiguration(config => config.AddProfile(seriesMappingProfile));
+        _mapper = new Mapper(seriesMappingConfig);
+
+        seriesController = new SeriesController(_mockSeriesService.Object, _mapper);
+    }
+
+    #region GetSeriesById method tests
+    [Test]
+    public async Task GetSeriesById_CallsServiceMethodOnce()
+    {
+        // Arrange
+        int testSeriesId = 1;
+
+        Series expectedServiceReturn = new Series() { Id = 1, Name = "TestSeries" };
+
+        _mockSeriesService.Setup(mock => mock.FindSeriesById(testSeriesId))
+                           .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        await seriesController.GetSeriesById(testSeriesId);
+
+        // Assert
+        _mockSeriesService.Verify(mock => mock.FindSeriesById(testSeriesId), Times.Once());
     }
 
     [Test]
-    public void GetSeriesById_DoesSomething()
+    public async Task GetSeriesById_OnValidRequest_ReturnsOkObjectResult()
     {
-        Assert.Pass();
+        // Arrange
+        int testSeriesId = 1;
+
+        Series expectedServiceReturn = new Series() { Id = 1, Name = "TestSeries" };
+
+        _mockSeriesService.Setup(mock => mock.FindSeriesById(testSeriesId))
+                           .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        var resultObject = await seriesController.GetSeriesById(testSeriesId);
+
+        // Assert
+        Assert.That(resultObject, Is.TypeOf<OkObjectResult>());
     }
+
+    [Test]
+    public async Task GetSeriesByIds_OnValidRequest_ReturnsMappedSeries()
+    {
+        // Arrange
+        int testSeriesId = 1;
+
+        Series expectedServiceReturn = new Series() { Id = 1, Name = "TestSeries" };
+        SeriesGetDTO expectedControllerReturn = new SeriesGetDTO() { Id = 1, Name = "TestSeries" };
+
+        _mockSeriesService.Setup(mock => mock.FindSeriesById(testSeriesId))
+                          .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        var resultObject = await seriesController.GetSeriesById(testSeriesId) as OkObjectResult;
+        var resultValue = resultObject!.Value as SeriesGetDTO;
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(resultValue!.Id, Is.EqualTo(expectedControllerReturn.Id));
+            Assert.That(resultValue.Name, Is.EqualTo(expectedControllerReturn.Name));
+        });
+    }
+
+    [Test]
+    public async Task GetSeriesById_OnInvalidRequest_ReturnsNotFoundObjectResult()
+    {
+        // Arrange
+        int testSeriesId = int.MaxValue;
+
+        Series? expectedServiceReturn = null;
+
+        _mockSeriesService.Setup(mock => mock.FindSeriesById(testSeriesId))
+                          .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        var resultObject = await seriesController.GetSeriesById(testSeriesId);
+
+        // Assert
+        Assert.That(resultObject, Is.TypeOf<NotFoundObjectResult>());
+    }
+    #endregion
+
+    #region IndexPopularSeries method tests
+    [Test]
+    public async Task IndexPopularSeries_CallsServiceMethodOnce()
+    {
+        // Arrange
+        List<Series> expectedServiceReturn = new List<Series>() {
+            new Series() { Id = 1, Name = "TestSeries1" },
+            new Series() { Id = 2, Name = "TestSeries2" }
+        };
+
+        _mockSeriesService.Setup(mock => mock.IndexPopularSeries())
+                          .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        await seriesController.IndexPopularSeries();
+
+        // Assert
+        _mockSeriesService.Verify(mock => mock.IndexPopularSeries(), Times.Once());
+    }
+
+    [Test]
+    public async Task IndexPopularSeries_OnValidRequest_ReturnsOkObjectResult()
+    {
+        // Arrange
+        List<Series> expectedServiceReturn = new List<Series>() {
+            new Series() { Id = 1, Name = "TestSeries1" },
+            new Series() { Id = 2, Name = "TestSeries2" }
+        };
+
+        _mockSeriesService.Setup(mock => mock.IndexPopularSeries())
+                          .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        var resultObject = await seriesController.IndexPopularSeries();
+
+        // Assert
+        Assert.That(resultObject, Is.TypeOf<OkObjectResult>());
+    }
+
+    [Test]
+    public async Task IndexPopularSeries_OnValidRequest_ReturnsMappedSeriesList()
+    {
+        // Arrange
+        List<Series> expectedServiceReturn = new List<Series>() {
+            new Series() { Id = 1, Name = "TestSeries1" },
+            new Series() { Id = 2, Name = "TestSeries2" }
+        };
+
+        List<SeriesGetDTO> expectedControllerReturn = new List<SeriesGetDTO>() {
+            new SeriesGetDTO() { Id = 1, Name = "TestSeries1" },
+            new SeriesGetDTO() { Id = 2, Name = "TestSeries2" }
+        };
+
+        _mockSeriesService.Setup(mock => mock.IndexPopularSeries())
+                          .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        var resultObject = await seriesController.IndexPopularSeries() as OkObjectResult;
+        var resultValue = resultObject!.Value as List<SeriesGetDTO>;
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(resultValue![0].Id, Is.EqualTo(expectedControllerReturn[0].Id));
+            Assert.That(resultValue[0].Name, Is.EqualTo(expectedControllerReturn[0].Name));
+            Assert.That(resultValue![1].Id, Is.EqualTo(expectedControllerReturn[1].Id));
+            Assert.That(resultValue[1].Name, Is.EqualTo(expectedControllerReturn[1].Name));
+        });
+    }
+
+    [Test]
+    public async Task IndexPopularSeries_OnInvalidRequest_ReturnsNotFoundObjectResult()
+    {
+        // Arrange
+        List<Series>? expectedServiceReturn = null;
+
+        _mockSeriesService.Setup(mock => mock.IndexPopularSeries())
+                          .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        var resultObject = await seriesController.IndexPopularSeries();
+
+        // Assert
+        Assert.That(resultObject, Is.TypeOf<NotFoundObjectResult>());
+    }
+    #endregion
+
+    #region IndexTopRatedSeries method tests
+    [Test]
+    public async Task IndexTopRatedSeries_CallsServiceMethodOnce()
+    {
+        // Arrange
+        List<Series> expectedServiceReturn = new List<Series>() {
+            new Series() { Id = 1, Name = "TestSeries1" },
+            new Series() { Id = 2, Name = "TestSeries2" }
+        };
+
+        _mockSeriesService.Setup(mock => mock.IndexTopRatedSeries())
+                          .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        await seriesController.IndexTopRatedSeries();
+
+        // Assert
+        _mockSeriesService.Verify(mock => mock.IndexTopRatedSeries(), Times.Once());
+    }
+
+    [Test]
+    public async Task IndexTopRatedSeries_OnValidRequest_ReturnsOkObjectResult()
+    {
+        // Arrange
+        List<Series> expectedServiceReturn = new List<Series>() {
+            new Series() { Id = 1, Name = "TestSeries1" },
+            new Series() { Id = 2, Name = "TestSeries2" }
+        };
+
+        _mockSeriesService.Setup(mock => mock.IndexTopRatedSeries())
+                          .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        var resultObject = await seriesController.IndexTopRatedSeries();
+
+        // Assert
+        Assert.That(resultObject, Is.TypeOf<OkObjectResult>());
+    }
+
+    [Test]
+    public async Task IndexTopRatedSeries_OnValidRequest_ReturnsMappedSeriesList()
+    {
+        // Arrange
+        List<Series> expectedServiceReturn = new List<Series>() {
+            new Series() { Id = 1, Name = "TestSeries1" },
+            new Series() { Id = 2, Name = "TestSeries2" }
+        };
+
+        List<SeriesGetDTO> expectedControllerReturn = new List<SeriesGetDTO>() {
+            new SeriesGetDTO() { Id = 1, Name = "TestSeries1" },
+            new SeriesGetDTO() { Id = 2, Name = "TestSeries2" }
+        };
+
+        _mockSeriesService.Setup(mock => mock.IndexTopRatedSeries())
+                          .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        var resultObject = await seriesController.IndexTopRatedSeries() as OkObjectResult;
+        var resultValue = resultObject!.Value as List<SeriesGetDTO>;
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(resultValue![0].Id, Is.EqualTo(expectedControllerReturn[0].Id));
+            Assert.That(resultValue[0].Name, Is.EqualTo(expectedControllerReturn[0].Name));
+            Assert.That(resultValue![1].Id, Is.EqualTo(expectedControllerReturn[1].Id));
+            Assert.That(resultValue[1].Name, Is.EqualTo(expectedControllerReturn[1].Name));
+        });
+    }
+
+    [Test]
+    public async Task IndexTopRatedSeries_OnInvalidRequest_ReturnsNotFoundObjectResult()
+    {
+        // Arrange
+        List<Series>? expectedServiceReturn = null;
+
+        _mockSeriesService.Setup(mock => mock.IndexTopRatedSeries())
+                          .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        var resultObject = await seriesController.IndexTopRatedSeries();
+
+        // Assert
+        Assert.That(resultObject, Is.TypeOf<NotFoundObjectResult>());
+    }
+    #endregion
+
+    #region GetSeriesByKeywords method tests
+    [Test]
+    public async Task GetSeriesByKeywords_CallsServiceMethodOnce()
+    {
+        // Arrange
+        string testQuery = "test";
+
+        List<Series>? expectedServiceReturn = new List<Series>() {
+            new Series() { Id = 1, Name = "TestSeries1" },
+            new Series() { Id = 2, Name = "TestSeries2" },
+        };
+
+        _mockSeriesService.Setup(mock => mock.FindSeriesByKeywords(testQuery))
+                          .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        await seriesController.GetSeriesByKeywords(testQuery);
+
+        // Assert
+        _mockSeriesService.Verify(mock => mock.FindSeriesByKeywords(testQuery), Times.Once());
+    }
+
+    [Test]
+    public async Task GetSeriesByKeywords_OnValidRequest_ReturnsOkObjectResult()
+    {
+        // Arrange
+        string testQuery = "test";
+
+        List<Series>? expectedServiceReturn = new List<Series>() {
+            new Series() { Id = 1, Name = "TestSeries1" },
+            new Series() { Id = 2, Name = "TestSeries2" },
+        };
+
+        _mockSeriesService.Setup(mock => mock.FindSeriesByKeywords(testQuery))
+                          .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        var resultObject = await seriesController.GetSeriesByKeywords(testQuery);
+
+        // Assert
+        Assert.That(resultObject, Is.TypeOf<OkObjectResult>());
+    }
+
+    [Test]
+    public async Task GetSeriesByKeywords_OnValidRequest_ReturnsMappedSeriesList()
+    {
+        // Arrange
+        string testQuery = "test";
+
+        List<Series>? expectedServiceReturn = new List<Series>() {
+            new Series() { Id = 1, Name = "TestSeries1" },
+            new Series() { Id = 2, Name = "TestSeries2" },
+        };
+
+        List<SeriesGetDTO>? expectedControllerReturn = new List<SeriesGetDTO>() {
+            new SeriesGetDTO() { Id = 1, Name = "TestSeries1" },
+            new SeriesGetDTO() { Id = 2, Name = "TestSeries2" },
+        };
+
+        _mockSeriesService.Setup(mock => mock.FindSeriesByKeywords(testQuery))
+                          .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        var resultObject = await seriesController.GetSeriesByKeywords(testQuery) as OkObjectResult;
+        var resultValue = resultObject!.Value as List<SeriesGetDTO>;
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(resultValue![0].Id, Is.EqualTo(expectedControllerReturn[0].Id));
+            Assert.That(resultValue[0].Name, Is.EqualTo(expectedControllerReturn[0].Name));
+            Assert.That(resultValue![1].Id, Is.EqualTo(expectedControllerReturn[1].Id));
+            Assert.That(resultValue[1].Name, Is.EqualTo(expectedControllerReturn[1].Name));
+        });
+    }
+
+    [Test]
+    public async Task GetSeriesByKeywords_OnNoMatches_ReturnsNotFoundObjectResult()
+    {
+        // Arrange
+        string testQuery = "Test Fail";
+
+        List<Series>? expectedServiceReturn = null;
+
+        _mockSeriesService.Setup(mock => mock.FindSeriesByKeywords(testQuery))
+                          .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        var resultObject = await seriesController.GetSeriesByKeywords(testQuery);
+
+        // Assert
+        Assert.That(resultObject, Is.TypeOf<NotFoundObjectResult>());
+    }
+
+    [Test]
+    public async Task GetSeriesByKeywords_OnEmptyInput_ReturnsBadRequestObjectResult()
+    {
+        // Arrange
+        string testQuery = "";
+
+        // Act
+        var resultObject = await seriesController.GetSeriesByKeywords(testQuery);
+
+        // Assert
+        Assert.That(resultObject, Is.TypeOf<BadRequestObjectResult>());
+    }
+    #endregion
+
+    #region GetRecommendationsById method tests
+    [Test]
+    public async Task GetRecommendationsById_CallsServiceMethodOnce()
+    {
+        // Arrange
+        int testSeriesId = 1;
+
+        List<Series> expectedServiceReturn = new List<Series>() {
+            new Series() { Id = 1, Name = "TestSeries1" },
+            new Series() { Id = 2, Name = "TestSeries2" }
+        };
+
+        _mockSeriesService.Setup(mock => mock.FindRecommendationsById(testSeriesId))
+                          .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        await seriesController.GetRecommendationsById(testSeriesId);
+
+        // Assert
+        _mockSeriesService.Verify(mock => mock.FindRecommendationsById(testSeriesId), Times.Once());
+    }
+
+    [Test]
+    public async Task GetRecommendationsById_OnValidRequest_ReturnsOkObjectResult()
+    {
+        // Arrange
+        int testSeriesId = 1;
+
+        List<Series> expectedServiceReturn = new List<Series>() {
+            new Series() { Id = 1, Name = "TestSeries1" },
+            new Series() { Id = 2, Name = "TestSeries2" }
+        };
+
+        _mockSeriesService.Setup(mock => mock.FindRecommendationsById(testSeriesId))
+                          .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        var resultObject = await seriesController.GetRecommendationsById(testSeriesId);
+
+        // Assert
+        Assert.That(resultObject, Is.TypeOf<OkObjectResult>());
+    }
+
+    [Test]
+    public async Task GetRecommendationsById_OnValidRequest_ReturnsMappedSeriesList()
+    {
+        // Arrange
+        int testSeriesId = 1;
+
+        List<Series> expectedServiceReturn = new List<Series>() {
+            new Series() { Id = 1, Name = "TestSeries1" },
+            new Series() { Id = 2, Name = "TestSeries2" }
+        };
+
+        List<SeriesGetDTO> expectedControllerReturn = new List<SeriesGetDTO>() {
+            new SeriesGetDTO() { Id = 1, Name = "TestSeries1" },
+            new SeriesGetDTO() { Id = 2, Name = "TestSeries2" }
+        };
+
+        _mockSeriesService.Setup(mock => mock.FindRecommendationsById(testSeriesId))
+                          .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        var resultObject = await seriesController.GetRecommendationsById(testSeriesId) as OkObjectResult;
+        var resultValue = resultObject!.Value as List<SeriesGetDTO>;
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(resultValue![0].Id, Is.EqualTo(expectedControllerReturn[0].Id));
+            Assert.That(resultValue[0].Name, Is.EqualTo(expectedControllerReturn[0].Name));
+            Assert.That(resultValue![1].Id, Is.EqualTo(expectedControllerReturn[1].Id));
+            Assert.That(resultValue[1].Name, Is.EqualTo(expectedControllerReturn[1].Name));
+        });
+    }
+
+    [Test]
+    public async Task GetRecommendationsById_OnInvalidRequest_ReturnsNotFoundObjectResult()
+    {
+        // Arrange
+        int testSeriesId = int.MaxValue;
+
+        List<Series>? expectedServiceReturn = null;
+
+        _mockSeriesService.Setup(mock => mock.FindRecommendationsById(testSeriesId))
+                          .ReturnsAsync(expectedServiceReturn);
+
+        // Act
+        var resultObject = await seriesController.GetRecommendationsById(testSeriesId);
+
+        // Assert
+        Assert.That(resultObject, Is.TypeOf<NotFoundObjectResult>());
+    }
+    #endregion
 }

--- a/Spreeview/SpreeviewTests/ServiceTests/EpisodeServiceTests.cs
+++ b/Spreeview/SpreeviewTests/ServiceTests/EpisodeServiceTests.cs
@@ -3,7 +3,7 @@ using Moq;
 using SpreeviewAPI.Services.Implementations;
 using SpreeviewAPI.Utilities;
 
-namespace SpreeviewTests.ControllerTests;
+namespace SpreeviewTests.ServiceTests;
 
 public class EpisodeServiceTests
 {

--- a/Spreeview/SpreeviewTests/ServiceTests/EpisodeServiceTests.cs
+++ b/Spreeview/SpreeviewTests/ServiceTests/EpisodeServiceTests.cs
@@ -1,6 +1,87 @@
-﻿namespace SpreeviewTests.ControllerTests;
+﻿using CommonLibrary.DataClasses.EpisodeModel;
+using Moq;
+using SpreeviewAPI.Services.Implementations;
+using SpreeviewAPI.Utilities;
+
+namespace SpreeviewTests.ControllerTests;
 
 public class EpisodeServiceTests
 {
+    Mock<IRequestManager> _mockRequestManager;
+    EpisodeService episodeService;
 
+    [SetUp]
+    public void Setup()
+    {
+        _mockRequestManager = new Mock<IRequestManager>();
+        episodeService = new EpisodeService(_mockRequestManager.Object);
+    }
+
+    #region FindEpisodeByIds method tests
+    [Test]
+    public async Task FindEpisodeByIds_CallsUtilityMethodOnce()
+    {
+        // Arrange
+        int testSeriesId = 1;
+        int testSeasonNum = 2;
+        int testEpisodeNum = 3;
+
+        string urlSuffix = $"tv/{testSeriesId}/season/{testSeasonNum}/episode/{testEpisodeNum}";
+
+        Episode expectedUtilityReturn = new Episode() { Id = 1, Title = "TestEpisode" };
+
+        _mockRequestManager.Setup(mock => mock.TmdbGetAsync<Episode>(urlSuffix))
+                           .ReturnsAsync(expectedUtilityReturn);
+
+        // Act
+        await episodeService.FindEpisodeByIds(testSeriesId, testSeasonNum, testEpisodeNum);
+
+        // Assert
+        _mockRequestManager.Verify(mock => mock.TmdbGetAsync<Episode>(urlSuffix), Times.Once());
+    }
+
+    [Test]
+    public async Task FindEpisodeByIds_OnValidRequest_ReturnsEpisodeType()
+    {
+        // Arrange
+        int testSeriesId = 1;
+        int testSeasonNum = 2;
+        int testEpisodeNum = 3;
+
+        string urlSuffix = $"tv/{testSeriesId}/season/{testSeasonNum}/episode/{testEpisodeNum}";
+
+        Episode expectedUtilityReturn = new Episode() { Id = 1, Title = "TestEpisode" };
+
+        _mockRequestManager.Setup(mock => mock.TmdbGetAsync<Episode>(urlSuffix))
+                           .ReturnsAsync(expectedUtilityReturn);
+
+        // Act
+        var result = await episodeService.FindEpisodeByIds(testSeriesId, testSeasonNum, testEpisodeNum);
+
+        // Assert
+        Assert.That(result, Is.TypeOf<Episode>());
+    }
+
+    [Test]
+    public async Task FindEpisodeByIds_OnInvalidRequest_ReturnsNull()
+    {
+        // Arrange
+        int testSeriesId = int.MaxValue;
+        int testSeasonNum = int.MaxValue;
+        int testEpisodeNum = int.MaxValue;
+
+        string urlSuffix = $"tv/{testSeriesId}/season/{testSeasonNum}/episode/{testEpisodeNum}";
+
+        Episode? expectedUtilityReturn = null;
+
+        _mockRequestManager.Setup(mock => mock.TmdbGetAsync<Episode>(urlSuffix))
+                           .ReturnsAsync(expectedUtilityReturn);
+
+        // Act
+        var result = await episodeService.FindEpisodeByIds(testSeriesId, testSeasonNum, testEpisodeNum);
+
+        // Assert
+        Assert.That(result, Is.Null);
+    }
+    #endregion
 }

--- a/Spreeview/SpreeviewTests/ServiceTests/ReviewServiceTests.cs
+++ b/Spreeview/SpreeviewTests/ServiceTests/ReviewServiceTests.cs
@@ -1,4 +1,4 @@
-﻿namespace SpreeviewTests.ControllerTests;
+﻿namespace SpreeviewTests.ServiceTests;
 
 public class ReviewServiceTests
 {

--- a/Spreeview/SpreeviewTests/ServiceTests/SeasonServiceTests.cs
+++ b/Spreeview/SpreeviewTests/ServiceTests/SeasonServiceTests.cs
@@ -1,0 +1,84 @@
+﻿using CommonLibrary.DataClasses.SeasonModel;
+using Moq;
+using SpreeviewAPI.Services.Implementations;
+using SpreeviewAPI.Utilities;
+
+namespace SpreeviewTests.ServiceTests;
+
+internal class SeasonServiceTests
+{
+    Mock<IRequestManager> _mockRequestManager;
+    SeasonService seasonService;
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockRequestManager = new Mock<IRequestManager>();
+        seasonService = new SeasonService(_mockRequestManager.Object);
+    }
+
+    #region FindSeasonByIds method tests
+    [Test]
+    public async Task FindSeasonByIds_CallsUtilityMethodOnce()
+    {
+        // Arrange
+        int testSeriesId = 1;
+        int testSeasonNum = 2;
+
+        string urlSuffix = $"tv/{testSeriesId}/season/{testSeasonNum}";
+
+        Season expectedUtilityReturn = new Season() { Id = 1, SeasonNumber = 2 };
+
+        _mockRequestManager.Setup(mock => mock.TmdbGetAsync<Season>(urlSuffix))
+                           .ReturnsAsync(expectedUtilityReturn);
+
+        // Act
+        await seasonService.FindSeasonByIds(testSeriesId, testSeasonNum);
+
+        // Assert
+        _mockRequestManager.Verify(mock => mock.TmdbGetAsync<Season>(urlSuffix), Times.Once());
+    }
+
+    [Test]
+    public async Task FindSeasonByIds_OnValidRequest_ReturnsSeasonType()
+    {
+        // Arrange
+        int testSeriesId = 1;
+        int testSeasonNum = 2;
+
+        string urlSuffix = $"tv/{testSeriesId}/season/{testSeasonNum}";
+
+        Season expectedUtilityReturn = new Season() { Id = 1, SeasonNumber = 2 };
+
+        _mockRequestManager.Setup(mock => mock.TmdbGetAsync<Season>(urlSuffix))
+                           .ReturnsAsync(expectedUtilityReturn);
+
+        // Act
+        var result = await seasonService.FindSeasonByIds(testSeriesId, testSeasonNum);
+
+        // Assert
+        Assert.That(result, Is.TypeOf<Season>());
+    }
+
+    [Test]
+    public async Task FindSeasonByIds_OnInvalidRequest_ReturnsNull()
+    {
+        // Arrange
+        int testSeriesId = int.MaxValue;
+        int testSeasonNum = int.MaxValue;
+
+        string urlSuffix = $"tv/{testSeriesId}/season/{testSeasonNum}";
+
+        Season? expectedUtilityReturn = null;
+
+        _mockRequestManager.Setup(mock => mock.TmdbGetAsync<Season>(urlSuffix))
+                           .ReturnsAsync(expectedUtilityReturn);
+
+        // Act
+        var result = await seasonService.FindSeasonByIds(testSeriesId, testSeasonNum);
+
+        // Assert
+        Assert.That(result, Is.Null);
+    }
+    #endregion
+}

--- a/Spreeview/SpreeviewTests/ServiceTests/SeriesServiceTests.cs
+++ b/Spreeview/SpreeviewTests/ServiceTests/SeriesServiceTests.cs
@@ -1,5 +1,364 @@
-﻿namespace SpreeviewTests.ControllerTests;
+﻿using CommonLibrary.DataClasses.SeriesModel;
+using Moq;
+using SpreeviewAPI.Services.Implementations;
+using SpreeviewAPI.Utilities;
+using SpreeviewAPI.Wrappers;
+
+namespace SpreeviewTests.ServiceTests;
 
 public class SeriesServiceTests
 {
+    Mock<IRequestManager> _mockRequestManager;
+    SeriesService seriesService;
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockRequestManager = new Mock<IRequestManager>();
+        seriesService = new SeriesService(_mockRequestManager.Object);
+    }
+
+    #region FindSeriesById method tests
+    [Test]
+    public async Task FindSeriesById_CallsUtilityMethodOnce()
+    {
+        // Arrange
+        int testSeriesId = 1;
+
+        string urlSuffix = $"tv/{testSeriesId}";
+
+        Series expectedUtilityReturn = new Series() { Id = 1, Name = "TestSeries" };
+
+        _mockRequestManager.Setup(mock => mock.TmdbGetAsync<Series>(urlSuffix))
+                           .ReturnsAsync(expectedUtilityReturn);
+
+        // Act
+        await seriesService.FindSeriesById(testSeriesId);
+
+        // Assert
+        _mockRequestManager.Verify(mock => mock.TmdbGetAsync<Series>(urlSuffix), Times.Once());
+    }
+
+    [Test]
+    public async Task FindSeriesByIds_OnValidRequest_ReturnsSeriesType()
+    {
+        // Arrange
+        int testSeriesId = 1;
+
+        string urlSuffix = $"tv/{testSeriesId}";
+
+        Series expectedUtilityReturn = new Series() { Id = 1, Name = "TestSeries" };
+
+        _mockRequestManager.Setup(mock => mock.TmdbGetAsync<Series>(urlSuffix))
+                           .ReturnsAsync(expectedUtilityReturn);
+
+        // Act
+        var result = await seriesService.FindSeriesById(testSeriesId);
+
+        // Assert
+        Assert.That(result, Is.TypeOf<Series>());
+    }
+
+    [Test]
+    public async Task FindSeriesById_OnInvalidRequest_ReturnsNull()
+    {
+        // Arrange
+        int testSeriesId = int.MaxValue;
+
+        string urlSuffix = $"tv/{testSeriesId}";
+
+        Series? expectedUtilityReturn = null;
+
+        _mockRequestManager.Setup(mock => mock.TmdbGetAsync<Series>(urlSuffix))
+                           .ReturnsAsync(expectedUtilityReturn);
+
+        // Act
+        var result = await seriesService.FindSeriesById(testSeriesId);
+
+        // Assert
+        Assert.That(result, Is.Null);
+    }
+    #endregion
+
+    #region IndexPopularSeries method tests
+    [Test]
+    public async Task IndexPopularSeries_CallsUtilityMethodOnce()
+    {
+        // Arrange
+        string urlSuffix = $"trending/tv/week";
+
+        List<Series> expectedUtilityResults = new List<Series>()
+        {
+            new Series() { Id = 1, Name = "TestSeries1" },
+            new Series() { Id = 2, Name = "TestSeries2" }
+        };
+
+        SeriesResponse expectedUtilityResponse = new SeriesResponse() { Results = expectedUtilityResults };
+
+        _mockRequestManager.Setup(mock => mock.TmdbGetAsync<SeriesResponse>(urlSuffix))
+                           .ReturnsAsync(expectedUtilityResponse);
+
+        // Act
+        await seriesService.IndexPopularSeries();
+
+        // Assert
+        _mockRequestManager.Verify(mock => mock.TmdbGetAsync<SeriesResponse>(urlSuffix), Times.Once());
+    }
+
+    [Test]
+    public async Task IndexPopularSeries_OnValidRequest_ReturnsSeriesListType()
+    {
+        string urlSuffix = $"trending/tv/week";
+
+        List<Series> expectedUtilityResults = new List<Series>()
+        {
+            new Series() { Id = 1, Name = "TestSeries1" },
+            new Series() { Id = 2, Name = "TestSeries2" }
+        };
+
+        SeriesResponse expectedUtilityResponse = new SeriesResponse() { Results = expectedUtilityResults };
+
+        _mockRequestManager.Setup(mock => mock.TmdbGetAsync<SeriesResponse>(urlSuffix))
+                           .ReturnsAsync(expectedUtilityResponse);
+
+        // Act
+        var result = await seriesService.IndexPopularSeries();
+
+        // Assert
+        Assert.That(result, Is.TypeOf<List<Series>>());
+    }
+
+    [Test]
+    public async Task IndexPopularSeries_OnInvalidRequest_ReturnsNull()
+    {
+        // Arrange
+        string urlSuffix = $"trending/tv/week";
+
+        SeriesResponse? expectedUtilityResponse = null;
+
+        _mockRequestManager.Setup(mock => mock.TmdbGetAsync<SeriesResponse>(urlSuffix))
+                           .ReturnsAsync(expectedUtilityResponse);
+
+        // Act
+        var result = await seriesService.IndexPopularSeries();
+
+        // Assert
+        Assert.That(result, Is.Null);
+    }
+    #endregion
+
+    #region IndexTopRatedSeries method tests
+    [Test]
+    public async Task IndexTopRatedSeries_CallsUtilityMethodOnce()
+    {
+        // Arrange
+        string urlSuffix = $"tv/top_rated";
+
+        List<Series> expectedUtilityResults = new List<Series>()
+        {
+            new Series() { Id = 1, Name = "TestSeries1" },
+            new Series() { Id = 2, Name = "TestSeries2" }
+        };
+
+        SeriesResponse expectedUtilityResponse = new SeriesResponse() { Results = expectedUtilityResults };
+
+        _mockRequestManager.Setup(mock => mock.TmdbGetAsync<SeriesResponse>(urlSuffix))
+                           .ReturnsAsync(expectedUtilityResponse);
+
+        // Act
+        await seriesService.IndexTopRatedSeries();
+
+        // Assert
+        _mockRequestManager.Verify(mock => mock.TmdbGetAsync<SeriesResponse>(urlSuffix), Times.Once());
+    }
+
+    [Test]
+    public async Task IndexTopRatedSeries_OnValidRequest_ReturnsSeriesListType()
+    {
+        string urlSuffix = $"tv/top_rated";
+
+        List<Series> expectedUtilityResults = new List<Series>()
+        {
+            new Series() { Id = 1, Name = "TestSeries1" },
+            new Series() { Id = 2, Name = "TestSeries2" }
+        };
+
+        SeriesResponse expectedUtilityResponse = new SeriesResponse() { Results = expectedUtilityResults };
+
+        _mockRequestManager.Setup(mock => mock.TmdbGetAsync<SeriesResponse>(urlSuffix))
+                           .ReturnsAsync(expectedUtilityResponse);
+
+        // Act
+        var result = await seriesService.IndexTopRatedSeries();
+
+        // Assert
+        Assert.That(result, Is.TypeOf<List<Series>>());
+    }
+
+    [Test]
+    public async Task IndexTopRatedSeries_OnInvalidRequest_ReturnsNull()
+    {
+        // Arrange
+        string urlSuffix = $"tv/top_rated";
+
+        SeriesResponse? expectedUtilityResponse = null;
+
+        _mockRequestManager.Setup(mock => mock.TmdbGetAsync<SeriesResponse>(urlSuffix))
+                           .ReturnsAsync(expectedUtilityResponse);
+
+        // Act
+        var result = await seriesService.IndexTopRatedSeries();
+
+        // Assert
+        Assert.That(result, Is.Null);
+    }
+    #endregion
+
+    #region FindSeriesByKeywords method tests
+    [Test]
+    public async Task FindSeriesByKeywords_CallsUtilityMethodOnce()
+    {
+        // Arrange
+        string testQuery = "test";
+
+        string urlSuffix = $"search/tv?query={testQuery}";
+
+        List<Series> expectedUtilityResults = new List<Series>()
+        {
+            new Series() { Id = 1, Name = "TestSeries1" },
+            new Series() { Id = 2, Name = "TestSeries2" }
+        };
+
+        SeriesResponse expectedUtilityResponse = new SeriesResponse() { Results = expectedUtilityResults };
+
+        _mockRequestManager.Setup(mock => mock.TmdbGetAsync<SeriesResponse>(urlSuffix))
+                           .ReturnsAsync(expectedUtilityResponse);
+
+        // Act
+        await seriesService.FindSeriesByKeywords(testQuery);
+
+        // Assert
+        _mockRequestManager.Verify(mock => mock.TmdbGetAsync<SeriesResponse>(urlSuffix), Times.Once());
+    }
+
+    [Test]
+    public async Task FindSeriesByKeywords_OnValidRequest_ReturnsSeriesListType()
+    {
+        // Arrange
+        string testQuery = "test";
+
+        string urlSuffix = $"search/tv?query={testQuery}";
+
+        List<Series> expectedUtilityResults = new List<Series>()
+        {
+            new Series() { Id = 1, Name = "TestSeries1" },
+            new Series() { Id = 2, Name = "TestSeries2" }
+        };
+
+        SeriesResponse expectedUtilityResponse = new SeriesResponse() { Results = expectedUtilityResults };
+
+        _mockRequestManager.Setup(mock => mock.TmdbGetAsync<SeriesResponse>(urlSuffix))
+                           .ReturnsAsync(expectedUtilityResponse);
+
+        // Act
+        var result = await seriesService.FindSeriesByKeywords(testQuery);
+
+        // Assert
+        Assert.That(result, Is.TypeOf<List<Series>>());
+    }
+
+    [Test]
+    public async Task FindSeriesByKeywords_OnInvalidRequest_ReturnsNull()
+    {
+        // Arrange
+        string testQuery = "test";
+
+        string urlSuffix = $"search/tv?query={testQuery}";
+
+        SeriesResponse? expectedUtilityResponse = null;
+
+        _mockRequestManager.Setup(mock => mock.TmdbGetAsync<SeriesResponse>(urlSuffix))
+                           .ReturnsAsync(expectedUtilityResponse);
+
+        // Act
+        var result = await seriesService.FindSeriesByKeywords(testQuery);
+
+        // Assert
+        Assert.That(result, Is.Null);
+    }
+    #endregion
+
+    #region FindRecommendationsById method tests
+    [Test]
+    public async Task FindRecommendationsById_CallsUtilityMethodOnce()
+    {
+        // Arrange
+        int testSeriesId = 1;
+
+        string urlSuffix = $"tv/{testSeriesId}/recommendations";
+
+        List<Series> expectedUtilityResults = new List<Series>()
+        {
+            new Series() { Id = 1, Name = "TestSeries1" },
+            new Series() { Id = 2, Name = "TestSeries2" }
+        };
+
+        SeriesResponse expectedUtilityResponse = new SeriesResponse() { Results = expectedUtilityResults };
+
+        _mockRequestManager.Setup(mock => mock.TmdbGetAsync<SeriesResponse>(urlSuffix))
+                           .ReturnsAsync(expectedUtilityResponse);
+
+        // Act
+        await seriesService.FindRecommendationsById(testSeriesId);
+
+        // Assert
+        _mockRequestManager.Verify(mock => mock.TmdbGetAsync<SeriesResponse>(urlSuffix), Times.Once());
+    }
+
+    [Test]
+    public async Task FindRecommendationsById_OnValidRequest_ReturnsSeriesListType()
+    {
+        // Arrange
+        int testSeriesId = 1;
+
+        string urlSuffix = $"tv/{testSeriesId}/recommendations";
+
+        List<Series> expectedUtilityResults = new List<Series>()
+        {
+            new Series() { Id = 1, Name = "TestSeries1" },
+            new Series() { Id = 2, Name = "TestSeries2" }
+        };
+
+        SeriesResponse expectedUtilityResponse = new SeriesResponse() { Results = expectedUtilityResults };
+
+        _mockRequestManager.Setup(mock => mock.TmdbGetAsync<SeriesResponse>(urlSuffix))
+                           .ReturnsAsync(expectedUtilityResponse);
+
+        // Act
+        var result = await seriesService.FindRecommendationsById(testSeriesId);
+
+        // Assert
+        Assert.That(result, Is.TypeOf<List<Series>>());
+    }
+
+    [Test]
+    public async Task FindRecommendationsById_OnInvalidRequest_ReturnsNull()
+    {
+        // Arrange
+        int testSeriesId = int.MaxValue;
+
+        string urlSuffix = $"tv/{testSeriesId}/recommendations";
+
+        SeriesResponse? expectedUtilityResponse = null;
+
+        _mockRequestManager.Setup(mock => mock.TmdbGetAsync<SeriesResponse>(urlSuffix))
+                           .ReturnsAsync(expectedUtilityResponse);
+
+        // Act
+        var result = await seriesService.FindRecommendationsById(testSeriesId);
+
+        // Assert
+        Assert.That(result, Is.Null);
+    }
+    #endregion
 }

--- a/Spreeview/SpreeviewTests/SpreeviewTests.csproj
+++ b/Spreeview/SpreeviewTests/SpreeviewTests.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\CommonLibrary\CommonLibrary.csproj" />
     <ProjectReference Include="..\SpreeviewAPI\SpreeviewAPI.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
- Add tests for Episode, Season and Series controllers and services
- Implement (injected) RequestsManager to handle HTTP calls to external API
- Edit some Series method syntax for clarity between controllers and services
- Add small messages to NotFound controller returns