### PR TITLE
fix: Fix Series GET by ID endpoint for certain TMDb outputs

### DIFF
--- a/Spreeview/CommonLibrary/DataClasses/SeasonModel/Season.cs
+++ b/Spreeview/CommonLibrary/DataClasses/SeasonModel/Season.cs
@@ -14,7 +14,7 @@ public class Season : IEntity
 	public int SeasonNumber { get; set; }
 
 	[JsonPropertyName("air_date")]
-	public DateOnly ReleaseDate { get; set; }
+	public DateOnly? ReleaseDate { get; set; }
 
 	[JsonPropertyName("poster_path")]
 	public string PosterPath { get; set; }

--- a/Spreeview/CommonLibrary/DataClasses/SeasonModel/SeasonGetDTO.cs
+++ b/Spreeview/CommonLibrary/DataClasses/SeasonModel/SeasonGetDTO.cs
@@ -7,7 +7,7 @@ public class SeasonGetDTO : IGetDTO
 	public int Id { get; set; }
     public string SeasonName { get; set; }
     public int SeasonNumber { get; set; }
-	public DateOnly ReleaseDate { get; set; }
+	public DateOnly? ReleaseDate { get; set; }
 	public string PosterPath { get; set; }
 	public List<Episode> Episodes { get; set; }
 	public int SeriesId { get; set; }


### PR DESCRIPTION
- ReleaseDate output from TMDb Seasons can be null, which would break the mapping/response.