### PR TITLE
feat: Modify comment and review endpoints to be based on user authentication

### DIFF
--- a/Spreeview/CommonLibrary/DataClasses/CommentModel/CommentInsertDTO.cs
+++ b/Spreeview/CommonLibrary/DataClasses/CommentModel/CommentInsertDTO.cs
@@ -6,6 +6,5 @@ namespace CommonLibrary.DataClasses.CommentModel
     {
 		public string Contents { get; set; }
 		public int ReviewId { get; set; }
-		public int UserId { get; set; }
 	}
 }

--- a/Spreeview/CommonLibrary/DataClasses/ReviewModel/ReviewInsertDTO.cs
+++ b/Spreeview/CommonLibrary/DataClasses/ReviewModel/ReviewInsertDTO.cs
@@ -4,7 +4,6 @@ namespace CommonLibrary.DataClasses.ReviewModel
 {
     public class ReviewInsertDTO : IInsertDTO
     {
-		public int UserId { get; set; }
 		public int SeriesId { get; set; }
 		public int EpisodeId { get; set; }
 		[MaxLength(1000)]

--- a/Spreeview/SpreeviewAPI/Controllers/Implementations/CommentController.cs
+++ b/Spreeview/SpreeviewAPI/Controllers/Implementations/CommentController.cs
@@ -1,5 +1,6 @@
 using AutoMapper;
 using CommonLibrary.DataClasses.CommentModel;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SpreeviewAPI.Services.Implementations;
 
@@ -54,6 +55,7 @@ public class CommentController : ControllerBase, ICommentController
         return Ok(responseDto);
     }
 
+    [Authorize]
     [HttpPost]
     public async Task<ActionResult> Create(CommentInsertDTO commentDto)
     {
@@ -65,6 +67,7 @@ public class CommentController : ControllerBase, ICommentController
         return Ok(responseDto);
     }
 
+    [Authorize]
     [HttpPut]
     public async Task<ActionResult> Update(CommentUpdateDTO commentDto)
     {
@@ -76,7 +79,8 @@ public class CommentController : ControllerBase, ICommentController
         var responseDto = _mapper.Map<CommentGetDTO>(response);
         return Ok(responseDto);
     }
-
+    
+    [Authorize]
     [HttpDelete("{id:int}")]
     public async Task<ActionResult> Delete(int id)
     {

--- a/Spreeview/SpreeviewAPI/Controllers/Implementations/CommentController.cs
+++ b/Spreeview/SpreeviewAPI/Controllers/Implementations/CommentController.cs
@@ -1,8 +1,11 @@
 using AutoMapper;
 using CommonLibrary.DataClasses.CommentModel;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using SpreeviewAPI.Models;
 using SpreeviewAPI.Services.Implementations;
+using SpreeviewAPI.Services.Interfaces;
 
 namespace SpreeviewAPI.Controllers.Implementations;
 
@@ -12,11 +15,13 @@ public class CommentController : ControllerBase, ICommentController
 {
     private readonly ICommentService _commentService;
     private readonly IMapper _mapper;
+    private readonly UserManager<ApplicationUser> _userManager;
 
-    public CommentController(ICommentService commentService, IMapper mapper)
+    public CommentController(ICommentService commentService, IMapper mapper, UserManager<ApplicationUser> userManager)
     {
         _commentService = commentService;
         _mapper = mapper;
+        _userManager = userManager;
     }
 
     [HttpGet]
@@ -60,7 +65,16 @@ public class CommentController : ControllerBase, ICommentController
     public async Task<ActionResult> Create(CommentInsertDTO commentDto)
     {
         if (!ModelState.IsValid) return BadRequest(ModelState);
+        
+        // Get the current user
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null) return Unauthorized();
+        
         var comment = _mapper.Map<Comment>(commentDto);
+        
+        // Set the user id from the current user
+        comment.UserId = user.Id;
+        
         var response = await _commentService.Create(comment);
         if (response == null) return BadRequest();
         var responseDto = _mapper.Map<CommentGetDTO>(response);
@@ -72,10 +86,23 @@ public class CommentController : ControllerBase, ICommentController
     public async Task<ActionResult> Update(CommentUpdateDTO commentDto)
     {
         if (!ModelState.IsValid) return BadRequest(ModelState);
+        
+        //TODO: Optimize this service / repository call path to avoid multiple database calls. 
+        // We could do with check user owns review service method.
+        
+        //Get the comment if exists
         var exists = await _commentService.GetById(commentDto.Id);
         if (exists == null) return NotFound();
+        
+        // Get the current user
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null) return Unauthorized();
+        
+        // Check if user owns the comment
+        if (exists.UserId != user.Id) return Unauthorized();
+        
         var response = await _commentService.Update(commentDto);
-        if (response == null) return BadRequest();
+        if (response == null) return BadRequest(); //TODO: this should maybe be NotFound to match ReviewController
         var responseDto = _mapper.Map<CommentGetDTO>(response);
         return Ok(responseDto);
     }
@@ -84,6 +111,20 @@ public class CommentController : ControllerBase, ICommentController
     [HttpDelete("{id:int}")]
     public async Task<ActionResult> Delete(int id)
     {
+        //TODO: Optimize this service / repository call path to avoid multiple database calls. 
+        // We could do with check user owns review service method.
+        
+        //Get comment if exists
+        var exists = await _commentService.GetById(id);
+        if(exists == null) return NotFound();
+        
+        // Get the current user
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null) return Unauthorized();
+        
+        // Check if user owns the review
+        if (exists.UserId != user.Id) return Unauthorized();
+        
         var response = await _commentService.Delete(id);
         return response ? NoContent() : NotFound();
     }

--- a/Spreeview/SpreeviewAPI/Controllers/Implementations/ReviewController.cs
+++ b/Spreeview/SpreeviewAPI/Controllers/Implementations/ReviewController.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using CommonLibrary.DataClasses.ReviewModel;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SpreeviewAPI.Controllers.Interfaces;
 using SpreeviewAPI.Services.Interfaces;
@@ -63,6 +64,7 @@ public class ReviewController : ControllerBase, IReviewController
         return Ok(responseDto);
     }
 
+    [Authorize]
     [HttpPost]
     public async Task<ActionResult> Create(ReviewInsertDTO reviewDto)
     {
@@ -73,6 +75,7 @@ public class ReviewController : ControllerBase, IReviewController
         return Ok(_mapper.Map<ReviewGetDTO>(response));
     }
 
+    [Authorize]
     [HttpPut]
     public async Task<ActionResult> Edit(ReviewUpdateDTO reviewDto)
     {
@@ -85,6 +88,7 @@ public class ReviewController : ControllerBase, IReviewController
         return Ok(responseDto);
     }
 
+    [Authorize]
     [HttpDelete("{id:int}")]
     public async Task<ActionResult> Delete(int id)
     {

--- a/Spreeview/SpreeviewAPI/Controllers/Implementations/ReviewController.cs
+++ b/Spreeview/SpreeviewAPI/Controllers/Implementations/ReviewController.cs
@@ -1,8 +1,12 @@
-﻿using AutoMapper;
+﻿using System.Security.Claims;
+using AutoMapper;
+using Azure.Core;
 using CommonLibrary.DataClasses.ReviewModel;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using SpreeviewAPI.Controllers.Interfaces;
+using SpreeviewAPI.Models;
 using SpreeviewAPI.Services.Interfaces;
 
 namespace SpreeviewAPI.Controllers.Implementations;
@@ -13,10 +17,13 @@ public class ReviewController : ControllerBase, IReviewController
 {
     private readonly IMapper _mapper;
     private readonly IReviewService _reviewService;
-    public ReviewController(IReviewService reviewService, IMapper mapper)
+    private readonly UserManager<ApplicationUser> _userManager;
+    
+    public ReviewController(IReviewService reviewService, IMapper mapper, UserManager<ApplicationUser> userManager)
     {
         _mapper = mapper;
         _reviewService = reviewService;
+        _userManager = userManager;
     }
 
     [HttpGet]
@@ -69,7 +76,16 @@ public class ReviewController : ControllerBase, IReviewController
     public async Task<ActionResult> Create(ReviewInsertDTO reviewDto)
     {
         if(!ModelState.IsValid) return BadRequest();
+        
+        // Get the current user
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null) return Unauthorized();
+        
         var review = _mapper.Map<Review>(reviewDto);
+        
+        // Set the user id from the current user
+        review.UserId = user.Id;
+        
         var response = await _reviewService.Create(review);
         if(response == null) return NotFound();
         return Ok(_mapper.Map<ReviewGetDTO>(response));
@@ -80,8 +96,21 @@ public class ReviewController : ControllerBase, IReviewController
     public async Task<ActionResult> Edit(ReviewUpdateDTO reviewDto)
     {
         if(!ModelState.IsValid) return BadRequest();
+        
+        //TODO: Optimize this service / repository call path to avoid multiple database calls. 
+        // We could do with check user owns review service method.
+        
+        //Get the review if exists
         var exists = await _reviewService.GetById(reviewDto.Id);
         if(exists == null) return NotFound();
+        
+        // Get the current user
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null) return Unauthorized();
+        
+        // Check if user owns the review
+        if (exists.UserId != user.Id) return Unauthorized();
+        
         var response = await _reviewService.Edit(reviewDto);
         if(response == null) return NotFound();
         var responseDto = _mapper.Map<ReviewGetDTO>(response);
@@ -92,6 +121,20 @@ public class ReviewController : ControllerBase, IReviewController
     [HttpDelete("{id:int}")]
     public async Task<ActionResult> Delete(int id)
     {
+        //TODO: Optimize this service / repository call path to avoid multiple database calls. 
+        // We could do with check user owns review service method.
+        
+        //Get review if exists
+        var exists = await _reviewService.GetById(id);
+        if(exists == null) return NotFound();
+        
+        // Get the current user
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null) return Unauthorized();
+        
+        // Check if user owns the review
+        if (exists.UserId != user.Id) return Unauthorized();
+        
         var response = await _reviewService.Delete(id);
         return response ? NoContent() : NotFound();
     }


### PR DESCRIPTION

- Only authorized users can post, put or delete reviews / comments
- Modify the create, edit, delete functions (Post, Put, Delete endpoints)
to use the current logged in user Id.
- Post creates a new comment / review using the logged in user's id.
- Edit and delete only allow modification where the logged in user's id
matches the comment / review id.

BREAKING CHANGE: CommentInsertDTO.cs and ReviewInsertDTO.cs 
no longer takes a UserId. This is inferred from the current authorization claim.

TODO: Optimize database calls for checking ownership