### PR TITLE
feat: changed series card to display poster path if not null

### DIFF
--- a/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Components/HomeComponents/SeriesCard.razor
+++ b/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Components/HomeComponents/SeriesCard.razor
@@ -2,7 +2,7 @@
 @if (series != null)
 {
 	<a class="h-[20rem] w-[12rem] shadow-purple" href=@($"/series/{series.Id}")>
-		<img class="h-full m-auto object-cover overflow-hidden display-block" src=@(string.IsNullOrEmpty(series.CoverPath) ? $"https://image.tmdb.org/t/p/original{series.BannerPath}" : $"https://image.tmdb.org/t/p/original{series.CoverPath}") alt="@series.Name" />
+		<img class="h-full m-auto object-cover overflow-hidden display-block" src=@(string.IsNullOrEmpty(series.PosterPath) ? $"https://image.tmdb.org/t/p/original{series.BannerPath}" : $"https://image.tmdb.org/t/p/original{series.PosterPath}") alt="@series.Name" />
 	</a>
 }
 


### PR DESCRIPTION
small change for UX purpose - show poster path which usually includes name of show rather than just the banner/cover