### PR TITLE
fix: Resolve Episode display issues on frontend

### DIFF
--- a/Spreeview/CommonLibrary/DataClasses/EpisodeModel/Episode.cs
+++ b/Spreeview/CommonLibrary/DataClasses/EpisodeModel/Episode.cs
@@ -20,5 +20,5 @@ public class Episode : IEntity
 	public string Overview { get; set; }
 
 	[JsonPropertyName("runtime")]
-	public int Runtime { get; set; }
+	public int? Runtime { get; set; }
 }

--- a/Spreeview/CommonLibrary/DataClasses/EpisodeModel/EpisodeGetDTO.cs
+++ b/Spreeview/CommonLibrary/DataClasses/EpisodeModel/EpisodeGetDTO.cs
@@ -7,5 +7,5 @@ public class EpisodeGetDTO : IGetDTO
 	public int EpisodeNumber { get; set; }
     public string StillPath { get; set; }
 	public string Overview { get; set; }
-	public int Runtime { get; set; }
+	public int? Runtime { get; set; }
 }


### PR DESCRIPTION
- TMDb API can return a null int for Runtime, which would break the episode deserialisation process.