### PR TITLE
feat: Add custom theme colours to tailwind

### DIFF
--- a/Spreeview/SpreeviewFrontend/SpreeviewFrontend/tailwind.config.js
+++ b/Spreeview/SpreeviewFrontend/SpreeviewFrontend/tailwind.config.js
@@ -5,7 +5,20 @@ module.exports = {
         // "./node_modules/flowbite/**/*.js"
     ],
   theme: {
-    extend: {},
+        extend: {
+            colors: {
+                hFg: 'var(--hFg)',
+                hBg: 'var(--hBg)',
+                accent: 'var(--accent)',
+                container: 'var(--container)',
+                mFg: 'var(--mFg)',
+                mBg: 'var(--mBg)',
+                fFg: 'var(--fFg))',
+                fBg: 'var(--fBg)',
+                oFg: 'var(--oFg)',
+                oBg: 'var(--oBg)',
+            },
+        },
   },
     plugins: [
         // require('flowbite/plugin')

--- a/Spreeview/SpreeviewFrontend/SpreeviewFrontend/wwwroot/css/CustCss.css
+++ b/Spreeview/SpreeviewFrontend/SpreeviewFrontend/wwwroot/css/CustCss.css
@@ -1,29 +1,31 @@
-﻿*[theme='light'] {
-    /*var(val, defaultVal)*/
-    --hBg: #E0E0E0;
-    --hFg: #101010;
-    --accent: #8816FC;
-    --container: #888888;
-    --mBg: #FFFFFF;
-    --mFg: #000000;
-    --fBg: #E0E0E0;
-    --fFg: #101010;
-    --oBg: #E0E0E0;
-    --oFg: #101010;
-}
+﻿/*These theme preferences have been moved to app.css */
 
-*[theme='dark'] {
-    --hFg: #E0E0E0;
-    --hBg: #101010;
-    --accent: #FC6C16;
-    --container: #888888;
-    --mFg: #FFFFFF;
-    --mBg: #161616;
-    --fFg: #E0E0E0;
-    --fBg: #101010;
-    --oFg: #E0E0E0;
-    --oBg: #101010;
-}
+/**[theme='light'] {*/
+/*    !*var(val, defaultVal)*!*/
+/*    --hBg: #E0E0E0;*/
+/*    --hFg: #101010;*/
+/*    --accent: #8816FC;*/
+/*    --container: #888888;*/
+/*    --mBg: #FFFFFF;*/
+/*    --mFg: #000000;*/
+/*    --fBg: #E0E0E0;*/
+/*    --fFg: #101010;*/
+/*    --oBg: #E0E0E0;*/
+/*    --oFg: #101010;*/
+/*}*/
+
+/**[theme='dark'] {*/
+/*    --hFg: #E0E0E0;*/
+/*    --hBg: #101010;*/
+/*    --accent: #FC6C16;*/
+/*    --container: #888888;*/
+/*    --mFg: #FFFFFF;*/
+/*    --mBg: #161616;*/
+/*    --fFg: #E0E0E0;*/
+/*    --fBg: #101010;*/
+/*    --oFg: #E0E0E0;*/
+/*    --oBg: #101010;*/
+/*}*/
 
 /*actual CSS code here - turn into razor ??*/
 

--- a/Spreeview/SpreeviewFrontend/SpreeviewFrontend/wwwroot/css/app.css
+++ b/Spreeview/SpreeviewFrontend/SpreeviewFrontend/wwwroot/css/app.css
@@ -2,6 +2,49 @@
 @tailwind components;
 @tailwind utilities;
 
+/* 
+Custom Colors for Themes 
+------------------------
+Add any themes and custom colors here below. For any new theme variables added (eg. --hGb, --hFg) 
+a corresponding line must be added in tailwind.config.js under theme: extend: colors: 
+(e.g, hFg: 'var(--hFg)',
+
+To apply themes any of these colors, either a theme='light' attribute or theme='dark' must be applied to 
+the parent element on which these colors are used.
+*/
+
+@layer base {
+
+    *[theme='light'] {
+        /*var(val, defaultVal)*/
+        --hBg: #E0E0E0;
+        --hFg: #101010;
+        --accent: #8816FC;
+        --container: #888888;
+        --mBg: #FFFFFF;
+        --mFg: #000000;
+        --fBg: #E0E0E0;
+        --fFg: #101010;
+        --oBg: #E0E0E0;
+        --oFg: #101010;
+    }
+
+    *[theme='dark'] {
+        --hFg: #E0E0E0;
+        --hBg: #101010;
+        --accent: #FC6C16;
+        --container: #888888;
+        --mFg: #FFFFFF;
+        --mBg: #161616;
+        --fFg: #E0E0E0;
+        --fBg: #101010;
+        --oFg: #E0E0E0;
+        --oBg: #101010;
+    }
+}
+
+/* Other CSS */
+
 body, html {
     font-family: "Inter", serif;
     font-optical-sizing: auto;


### PR DESCRIPTION
Add the custom CSS theme colours to tailwind source, so that they are generated and usable as tailwind classes.