### PR TITLE
fix: Fix Episode loading for Specials

### DIFF
--- a/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Components/Series/SeriesInfo.razor
+++ b/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Components/Series/SeriesInfo.razor
@@ -25,7 +25,7 @@
 				</p>
 			</article>
 			<!-- Seasons section -->
-			@if (SeasonNumber > 0)
+			@if (SeasonNumber >= 0)
 			{
 				<SeasonLoader LoadingType="@LoadingType.SeasonInfo" seriesId="@series.Id" SelectEpisode="SelectEpisode" />
 			}


### PR DESCRIPTION
- Specials have a SeasonNumber of 0, which meant that their SeasonLoader were not being generated.