### PR TITLE
fix: Fix shared auth state across all users

### DIFF
--- a/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Services/AccountManagement/AccountManagementService.cs
+++ b/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Services/AccountManagement/AccountManagementService.cs
@@ -7,14 +7,11 @@ using SpreeviewAPI.Wrappers;
 
 namespace SpreeviewFrontend.Services.AccountManagement;
 
-public class AccountManagementService(
-    IHttpClientFactory httpClientFactory,
-    ILogger<AccountManagementService> logger)
-    : AuthenticationStateProvider, IAccountManagementService
+public class AccountManagementService : AuthenticationStateProvider, IAccountManagementService
 {
     
     // http client pointing to authentication api
-    private readonly HttpClient _httpClient = httpClientFactory.CreateClient("SpreeviewAPI");
+    private readonly HttpClient _httpClient;
     
     // json serializer options to use camelCase
     private readonly JsonSerializerOptions _jsonSerializerOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
@@ -24,6 +21,15 @@ public class AccountManagementService(
     
     // Field to store current boolean authenticated state 
     private bool _isAuthenticated;
+    
+    private readonly ILogger<AccountManagementService> _logger;
+
+    public AccountManagementService(HttpClient httpClient,
+        ILogger<AccountManagementService> logger)
+    {
+        _logger = logger;
+        _httpClient = httpClient;
+    }
 
     /// <summary>
     /// Get authentication state.
@@ -45,7 +51,7 @@ public class AccountManagementService(
             // Check if user is not authenticated
             if (!userInfoResponse.IsSuccessStatusCode)
             {
-                logger.LogInformation("Could not authenticate user. Perhaps they are not logged in?");
+                _logger.LogInformation("Could not authenticate user. Perhaps they are not logged in?");
                 return new AuthenticationState(_unauthenticated);
             }
             
@@ -56,7 +62,7 @@ public class AccountManagementService(
             // Check if user info exists:
             if (userInfo == null)
             {
-                logger.LogInformation("User is authenticated, but unable to retrieve user info.");
+                _logger.LogInformation("User is authenticated, but unable to retrieve user info.");
                 return new AuthenticationState(_unauthenticated);
             }
 
@@ -78,7 +84,7 @@ public class AccountManagementService(
             // Check if getting roles was not successful
             if (!userInfoResponse.IsSuccessStatusCode)
             {
-                logger.LogInformation("Unable to get user roles from API");
+                _logger.LogInformation("Unable to get user roles from API");
                 return new AuthenticationState(_unauthenticated);
             }
             
@@ -109,7 +115,7 @@ public class AccountManagementService(
         }
         catch (Exception e)
         {
-            logger.LogInformation("Could not authenticate user due to server error.");
+            _logger.LogInformation("Could not authenticate user due to server error.");
             return new AuthenticationState(_unauthenticated);
         }
     }
@@ -142,7 +148,7 @@ public class AccountManagementService(
         }
         catch (Exception e)
         {
-            logger.LogInformation("Could not register user due to server error.");
+            _logger.LogInformation("Could not register user due to server error.");
             return new ServiceResponse();
         }
         
@@ -177,7 +183,7 @@ public class AccountManagementService(
         }
         catch (Exception e)
         {
-            logger.LogInformation("Could not login user due to server error.");
+            _logger.LogInformation("Could not login user due to server error.");
             return new ServiceResponse();
         }
     }
@@ -198,7 +204,7 @@ public class AccountManagementService(
         }
         catch (Exception e)
         {
-            logger.LogInformation("Could not logout user due to server error.");
+            _logger.LogInformation("Could not logout user due to server error.");
             return new ServiceResponse();
         }
     }

--- a/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Services/ApiCommentService/ApiCommentService.cs
+++ b/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Services/ApiCommentService/ApiCommentService.cs
@@ -11,11 +11,9 @@ public class ApiCommentService : IApiCommentService
     private readonly HttpClient _httpClient;
     private readonly ILogger<ApiCommentService> _logger;
 
-    public ApiCommentService(IHttpClientFactory httpClientFactory, ILogger<ApiCommentService> logger)
+    public ApiCommentService(HttpClient httpClient, ILogger<ApiCommentService> logger)
     {
-        _httpClient = httpClientFactory.CreateClient("SpreeviewAPI");
-        _httpClient.BaseAddress = new Uri(_httpClient.BaseAddress, "api/comment/");
-
+        _httpClient = httpClient;
         _logger = logger;
     }
 
@@ -23,7 +21,7 @@ public class ApiCommentService : IApiCommentService
 	{
 		try
 		{
-			var response = await _httpClient.PostAsJsonAsync("", comment);
+			var response = await _httpClient.PostAsJsonAsync("api/Comment/", comment);
 			if (response != null)
 			{
 				Console.WriteLine(response.Content);
@@ -43,7 +41,7 @@ public class ApiCommentService : IApiCommentService
 		try
 		{
 			var response = await _httpClient.GetFromJsonAsync<List<CommentGetDTO>>(
-				$"review/{reviewId}");
+				$"api/comment/review/{reviewId}");
 
 			if (response != null)
 			{
@@ -62,7 +60,7 @@ public class ApiCommentService : IApiCommentService
     {
         try
         {
-            var response = await _httpClient.GetFromJsonAsync<List<CommentGetDTO>>($"user/{userId}");
+            var response = await _httpClient.GetFromJsonAsync<List<CommentGetDTO>>($"api/comment/user/{userId}");
             if (response != null)
             {
                 Console.WriteLine(response[0].Contents);

--- a/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Services/ApiEpisode/ApiEpisodeService.cs
+++ b/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Services/ApiEpisode/ApiEpisodeService.cs
@@ -8,10 +8,9 @@ public class ApiEpisodeService : IApiEpisodeService
     private readonly HttpClient _httpClient;
     private readonly ILogger<ApiEpisodeService> _logger;
 
-    public ApiEpisodeService(IHttpClientFactory httpClientFactory, ILogger<ApiEpisodeService> logger)
+    public ApiEpisodeService(HttpClient httpClient, ILogger<ApiEpisodeService> logger)
     {
-        _httpClient = httpClientFactory.CreateClient("SpreeviewAPI");
-        _httpClient.BaseAddress = new Uri(_httpClient.BaseAddress, "api/episode/");
+        _httpClient = httpClient;
         _logger = logger;
     }
     
@@ -20,7 +19,7 @@ public class ApiEpisodeService : IApiEpisodeService
         try
         {
             var response = await _httpClient.GetFromJsonAsync<EpisodeGetDTO>(
-                $"{seriesId}/{seasonNumber}/{episodeNumber}");
+                $"api/episode/{seriesId}/{seasonNumber}/{episodeNumber}");
             
             if (response != null)
             {

--- a/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Services/ApiHealth/ApiHealthService.cs
+++ b/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Services/ApiHealth/ApiHealthService.cs
@@ -11,10 +11,9 @@ public class ApiHealthService : IApiHealthService
     // json serializer options to use camelCase
     private readonly JsonSerializerOptions _jsonSerializerOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
-    public ApiHealthService(IHttpClientFactory httpClientFactory, ILogger<ApiHealthService> logger)
+    public ApiHealthService(HttpClient httpClient, ILogger<ApiHealthService> logger)
     {
-        _httpClient = httpClientFactory.CreateClient("SpreeviewAPI");
-        _httpClient.BaseAddress = new Uri(_httpClient.BaseAddress, "api/health/");
+        _httpClient = httpClient;
         _logger = logger;
     }
 
@@ -23,7 +22,7 @@ public class ApiHealthService : IApiHealthService
         try
         {
             // Contact backend
-            var result = await _httpClient.GetAsync("");
+            var result = await _httpClient.GetAsync("api/health/");
 
             // Commented out, due to 503 status code of "/api/health" Unhealthy responses
             //// If not successful

--- a/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Services/ApiIdentity/ApiIdentityService.cs
+++ b/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Services/ApiIdentity/ApiIdentityService.cs
@@ -6,17 +6,16 @@ public class ApiIdentityService : IApiIdentityService
 {
     private readonly HttpClient _httpClient; 
     
-    public ApiIdentityService(IHttpClientFactory httpClientFactory)
+    public ApiIdentityService(HttpClient httpClient)
     {
-        _httpClient = httpClientFactory.CreateClient("SpreeviewAPI");
-        _httpClient.BaseAddress = new Uri(_httpClient.BaseAddress, "identity/");
+        _httpClient = httpClient;
     }
 
     public async Task<int> GetUserIdAsync()
     {
         try
         {
-            var result = await _httpClient.GetAsync("");
+            var result = await _httpClient.GetAsync("identity/");
             result.EnsureSuccessStatusCode();
             var content = await result.Content.ReadAsStringAsync();
             return int.Parse(content);

--- a/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Services/ApiReview/ApiReviewService.cs
+++ b/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Services/ApiReview/ApiReviewService.cs
@@ -9,10 +9,9 @@ public class ApiReviewService : IApiReviewService
     private readonly HttpClient _httpClient;
     private readonly ILogger<ApiReviewService> _logger;
 
-    public ApiReviewService(IHttpClientFactory httpClientFactory, ILogger<ApiReviewService> logger)
+    public ApiReviewService(HttpClient httpClient, ILogger<ApiReviewService> logger)
     {
-        _httpClient = httpClientFactory.CreateClient("SpreeviewAPI");
-        _httpClient.BaseAddress = new Uri(_httpClient.BaseAddress, "api/review/");
+        _httpClient = httpClient;
         _logger = logger;
     }
 
@@ -20,7 +19,7 @@ public class ApiReviewService : IApiReviewService
     {
         try
         {
-            var response = await _httpClient.GetFromJsonAsync<List<ReviewGetDTO>>($"user/{userId}");
+            var response = await _httpClient.GetFromJsonAsync<List<ReviewGetDTO>>($"api/review/user/{userId}");
             if (response != null)
             {
                 return new ServiceObjectResponse<List<ReviewGetDTO>>() { Type = ServiceResponseType.Success, Value = response };
@@ -37,7 +36,7 @@ public class ApiReviewService : IApiReviewService
     {
         try
         {
-            var response = await _httpClient.PostAsJsonAsync("", review);
+            var response = await _httpClient.PostAsJsonAsync("api/review/", review);
             if (response != null)
             {
                 Console.WriteLine(response.Content);
@@ -56,7 +55,7 @@ public class ApiReviewService : IApiReviewService
         try
         {
             var response = await _httpClient.GetFromJsonAsync<List<ReviewGetDTO>>(
-                $"episode/{episodeId}");
+                $"api/review/episode/{episodeId}");
 
             if (response != null)
             {

--- a/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Services/ApiSeason/ApiSeasonService.cs
+++ b/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Services/ApiSeason/ApiSeasonService.cs
@@ -9,10 +9,9 @@ public class ApiSeasonService : IApiSeasonService
     private readonly HttpClient _httpClient;
     private readonly ILogger<ApiSeasonService> _logger;
 
-    public ApiSeasonService(IHttpClientFactory httpClientFactory, ILogger<ApiSeasonService> logger)
+    public ApiSeasonService(HttpClient httpClient, ILogger<ApiSeasonService> logger)
     {
-        _httpClient = httpClientFactory.CreateClient("SpreeviewAPI");
-        _httpClient.BaseAddress = new Uri(_httpClient.BaseAddress, "api/season/");
+        _httpClient = httpClient;
         _logger = logger;
     }
     
@@ -21,7 +20,7 @@ public class ApiSeasonService : IApiSeasonService
         try
         {
             var response = await _httpClient.GetFromJsonAsync<SeasonGetDTO>(
-                $"{seriesId}/{seasonNumber}");
+                $"api/season/{seriesId}/{seasonNumber}");
 
             if (response != null)
             {

--- a/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Services/ApiSeries/ApiSeriesService.cs
+++ b/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Services/ApiSeries/ApiSeriesService.cs
@@ -9,10 +9,9 @@ public class ApiSeriesService : IApiSeriesService
     private readonly HttpClient _httpClient;
     private readonly ILogger<ApiSeriesService> _logger;
 
-    public ApiSeriesService(IHttpClientFactory httpClientFactory, ILogger<ApiSeriesService> logger)
+    public ApiSeriesService(HttpClient httpClient, ILogger<ApiSeriesService> logger)
     {
-	    _httpClient = httpClientFactory.CreateClient("SpreeviewAPI");
-	    _httpClient.BaseAddress = new Uri(_httpClient.BaseAddress, "api/series/");
+	    _httpClient = httpClient;
 	    Console.WriteLine(_httpClient.BaseAddress);
         _logger = logger;
     }
@@ -22,9 +21,7 @@ public class ApiSeriesService : IApiSeriesService
 			try
 			{
 				var response = await _httpClient.GetFromJsonAsync<List<SeriesGetDTO>>(
-					$"trending");
-
-				Console.WriteLine(_httpClient.BaseAddress + "trending");
+					$"api/series/trending");
 				
 				if (response != null)
 				{
@@ -45,7 +42,7 @@ public class ApiSeriesService : IApiSeriesService
 			try
 			{
 				var response = await _httpClient.GetFromJsonAsync<SeriesGetDTO>(
-					$"{id}");
+					$"api/series/{id}");
 
 				if (response != null)
 				{
@@ -66,7 +63,7 @@ public class ApiSeriesService : IApiSeriesService
 			try
 			{
 				var response = await _httpClient.GetFromJsonAsync<List<SeriesGetDTO>>(
-					$"search?query={query}");
+					$"api/series/search?query={query}");
 
 				if (response != null)
 				{

--- a/Spreeview/SpreeviewFrontend/SpreeviewFrontend/WebApplicationBuilderExtensions.cs
+++ b/Spreeview/SpreeviewFrontend/SpreeviewFrontend/WebApplicationBuilderExtensions.cs
@@ -50,11 +50,17 @@ public static class WebApplicationBuilderExtensions
         {
             throw new InvalidOperationException("BackendUrl not found in configuration.");
         }
+        
+        // Scoped HTTP client (one per circuit)
+        builder.Services.AddScoped(sp =>
+        {
+            // Set use default credentials to true, so that cookies are passed with the request
+            var client = new HttpClient(new HttpClientHandler() { UseDefaultCredentials = true });
+            client.BaseAddress = new Uri(backendUrl);
+            client.DefaultRequestHeaders.Add("X-Requested-With", ["XMLHttpRequest"]);
+            return client;
+        });
 
-        // Create a named HTTP client connecting to the backend. This is used for authentication and API services.
-        builder.Services
-            .AddHttpClient("SpreeviewAPI", client => client.BaseAddress = new Uri(backendUrl))
-            .AddHttpMessageHandler<CookieHandler>();
     }
 
     public static void SetupApiServices(this WebApplicationBuilder builder)


### PR DESCRIPTION
Fix the shared auth state across all users. This was caused by the Services.AddHttpClient method, which seems to scope the service across all circuits, rather than individual client / server connections.

Fix by replacing the named HttpClient with a scoped service provider, which creates a single httpclient for a single circuit.