### PR TITLE
fix/feat: Improve UX for reviews and comments

### DIFF
--- a/Spreeview/SpreeviewAPI/Controllers/Implementations/IdentityController.cs
+++ b/Spreeview/SpreeviewAPI/Controllers/Implementations/IdentityController.cs
@@ -35,6 +35,10 @@ public class IdentityController(SignInManager<ApplicationUser> signInManager, Us
     public async Task<ActionResult> GetUserNameById(int userId)
     {
         var user = await userManager.FindByIdAsync(userId.ToString());
-        return Ok(user!.UserName);
+        string email = user!.UserName!;
+
+        // "Creating" username from registered e-mail, until username registration is added
+        string userName = email.Split("@")[0];
+        return Ok(userName);
     }
 }

--- a/Spreeview/SpreeviewAPI/Controllers/Implementations/IdentityController.cs
+++ b/Spreeview/SpreeviewAPI/Controllers/Implementations/IdentityController.cs
@@ -1,5 +1,4 @@
-﻿using System.Security.Claims;
-using Microsoft.AspNetCore.Authorization;
+﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using SpreeviewAPI.Controllers.Interfaces;
@@ -30,5 +29,12 @@ public class IdentityController(SignInManager<ApplicationUser> signInManager, Us
     {
         var user = await userManager.GetUserAsync(User);
         return Ok(user.Id);
+    }
+
+    [HttpGet("/identity/{userId:int}")]
+    public async Task<ActionResult> GetUserNameById(int userId)
+    {
+        var user = await userManager.FindByIdAsync(userId.ToString());
+        return Ok(user!.UserName);
     }
 }

--- a/Spreeview/SpreeviewAPI/Controllers/Interfaces/IIdentityController.cs
+++ b/Spreeview/SpreeviewAPI/Controllers/Interfaces/IIdentityController.cs
@@ -5,4 +5,6 @@ namespace SpreeviewAPI.Controllers.Interfaces;
 public interface IIdentityController
 {
     Task<IActionResult> Logout([FromBody] object empty);
+    Task<ActionResult> GetUserId();
+    Task<ActionResult> GetUserNameById(int userId);
 }

--- a/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Components/Pages/Profile.razor
+++ b/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Components/Pages/Profile.razor
@@ -112,8 +112,9 @@
         UserId = await GetUserId();
         Reviews = (await ReviewService.GetReviewsByUserId(UserId)).Value;
         Comments = (await CommentService.GetCommentsByUserId(UserId)).Value;
-        Comments.Reverse();
-        Reviews.Reverse();
+
+        if (Comments != null) Comments.Reverse();
+        if (Reviews != null) Reviews.Reverse();
         StateHasChanged();
     }
 }

--- a/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Components/Reviews/ReviewCard.razor
+++ b/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Components/Reviews/ReviewCard.razor
@@ -2,14 +2,17 @@
 @using CommonLibrary.DataClasses.ReviewModel
 @using SpreeviewFrontend.Services.ApiCommentService
 @using SpreeviewFrontend.Services.ApiIdentity
+
 @rendermode InteractiveServer
+
 @inject IApiCommentService CommentService
 @inject IApiIdentityService IdentityService
 
 @if (review != null)
 {
-	int reviewTimeFromNow = (DateTime.Now - @review.DateAdded).Days;
+	string reviewUserName = Task.Run(() => GetUserNameByIdAsync(review.UserId)).Result;
 
+	int reviewTimeFromNow = (DateTime.Now - @review.DateAdded).Days;
 	string reviewTimeAgoString = GenerateTimeAgoString(reviewTimeFromNow);
 
 	<!-- Review card -->
@@ -17,10 +20,9 @@
 		<StarRating Rating="@review.Rating" />
 		<p class="text-lg">"@review.Contents"</p>
 		<div>
-			<p>User @review.UserId</p>
+			<p>User @reviewUserName</p>
 			<p class="text-sm">@reviewTimeAgoString</p>
 		</div>
-
 
 		<!-- Buttons -->
 		<div class="self-end flex items-center gap-2">
@@ -34,18 +36,18 @@
 				</button>
 			}
 
-  			<AuthorizeView>
-  				<Authorized>
-  					@if (DisplayedCommentForm.Contains(review.Id) == false && UserId == review.UserId)
-  					{
-  						<button class="h-8 w-8" @onclick="() => ToggleReviewEditor()">
-  							<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-pen" viewBox="0 0 16 16">
-  								<path d="m13.498.795.149-.149a1.207 1.207 0 1 1 1.707 1.708l-.149.148a1.5 1.5 0 0 1-.059 2.059L4.854 14.854a.5.5 0 0 1-.233.131l-4 1a.5.5 0 0 1-.606-.606l1-4a.5.5 0 0 1 .131-.232l9.642-9.642a.5.5 0 0 0-.642.056L6.854 4.854a.5.5 0 1 1-.708-.708L9.44.854A1.5 1.5 0 0 1 11.5.796a1.5 1.5 0 0 1 1.998-.001m-.644.766a.5.5 0 0 0-.707 0L1.95 11.756l-.764 3.057 3.057-.764L14.44 3.854a.5.5 0 0 0 0-.708z" />
-  							</svg>
-  						</button>
-  					}
-  				</Authorized>
-  			</AuthorizeView>
+			<AuthorizeView>
+				<Authorized>
+					@if (DisplayedCommentForm.Contains(review.Id) == false && UserId == review.UserId)
+					{
+						<button class="h-8 w-8" @onclick="() => ToggleReviewEditor()">
+							<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-pen" viewBox="0 0 16 16">
+								<path d="m13.498.795.149-.149a1.207 1.207 0 1 1 1.707 1.708l-.149.148a1.5 1.5 0 0 1-.059 2.059L4.854 14.854a.5.5 0 0 1-.233.131l-4 1a.5.5 0 0 1-.606-.606l1-4a.5.5 0 0 1 .131-.232l9.642-9.642a.5.5 0 0 0-.642.056L6.854 4.854a.5.5 0 1 1-.708-.708L9.44.854A1.5 1.5 0 0 1 11.5.796a1.5 1.5 0 0 1 1.998-.001m-.644.766a.5.5 0 0 0-.707 0L1.95 11.756l-.764 3.057 3.057-.764L14.44 3.854a.5.5 0 0 0 0-.708z" />
+							</svg>
+						</button>
+					}
+				</Authorized>
+			</AuthorizeView>
 		</div>
 
 		@if (DisplayedComments.Contains(review.Id) == true) {
@@ -54,10 +56,12 @@
 				<div class="flex flex-col gap-2 max-h-[300px] overflow-y-scroll">
 					@foreach (var comment in comments)
 					{
+						string commentUserName = Task.Run(() => GetUserNameByIdAsync(comment.UserId)).Result;
 						int commentTimeFromNow = (DateTime.Now - @comment.DateAdded).Days;
 						string commentTimeAgoString = GenerateTimeAgoString(commentTimeFromNow);
+
 						<div class="py-2 px-6 bg-white rounded-xl text-purple-600 self-start">
-							<p class="font-bold">User @comment.UserId <span class="text-sm font-light">@commentTimeAgoString</span></p>
+							<p class="font-bold">User @commentUserName <span class="text-sm font-light">@commentTimeAgoString</span></p>
 							<p>@comment.Contents</p>
 						</div>
 					}
@@ -88,6 +92,9 @@
 
 
 @code {
+	[CascadingParameter]
+	public bool RefreshReviews { get; set; }
+
 	[Parameter]
 	public ReviewGetDTO review { get; set; }
 
@@ -100,9 +107,6 @@
 	public string CommentInput { get; set; }
 
 	public bool IsContentEmpty { get; set; } = true;
-
-	[CascadingParameter]
-	public bool RefreshReviews { get; set; }
 
 	public int UserId { get; set; }
 
@@ -122,7 +126,6 @@
 			DisplayedComments.Add(reviewId);
 		}
 
-
 		if (DisplayedComments.Contains(reviewId) == false)
 		{
 			DisplayedCommentForm.Remove(reviewId);
@@ -131,7 +134,6 @@
 		{
 			DisplayedCommentForm.Add(reviewId);
 		}
-
 	} 
 
 	public string GenerateTimeAgoString(int daysAgo)
@@ -193,6 +195,20 @@
 			Console.WriteLine(e.Message);
 			throw;
 		}
+	}
+
+	private async Task<string> GetUserNameByIdAsync(int userId)
+	{
+		try
+		{
+			return (await IdentityService.GetUserNameByIdAsync(userId)).Value!;
+		}
+		catch (Exception e)
+		{
+			Console.WriteLine($"Error getting User Name for User ID {userId}");
+			Console.WriteLine(e.Message);
+		}
+		return "ERROR";
 	}
 
 	protected override async Task OnParametersSetAsync()

--- a/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Components/Reviews/ReviewCard.razor
+++ b/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Components/Reviews/ReviewCard.razor
@@ -18,9 +18,9 @@
 	<!-- Review card -->
 	<div class="p-6 flex flex-col gap-2 w-[80vw] sm:w-[60vw] m-auto font-semibold text-white bg-purple-600 rounded-2xl">
 		<StarRating Rating="@review.Rating" />
-		<p class="text-lg">"@review.Contents"</p>
+		<p class="text-lg italic">"@review.Contents"</p>
 		<div>
-			<p>User @reviewUserName</p>
+			<p>@reviewUserName</p>
 			<p class="text-sm">@reviewTimeAgoString</p>
 		</div>
 
@@ -61,8 +61,8 @@
 						string commentTimeAgoString = GenerateTimeAgoString(commentTimeFromNow);
 
 						<div class="py-2 px-6 bg-white rounded-xl text-purple-600 self-start">
-							<p class="font-bold">User @commentUserName <span class="text-sm font-light">@commentTimeAgoString</span></p>
-							<p>@comment.Contents</p>
+							<p class="font-bold">@commentUserName <span class="text-sm font-light">@commentTimeAgoString</span></p>
+							<p class="italic">@comment.Contents</p>
 						</div>
 					}
 				</div>

--- a/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Components/Reviews/ReviewEditor.razor
+++ b/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Components/Reviews/ReviewEditor.razor
@@ -2,19 +2,21 @@
 @using CommonLibrary.DataClasses.SeasonModel
 @using CommonLibrary.DataClasses.SeriesModel
 @using SpreeviewFrontend.Services.ApiReview
+
 @rendermode InteractiveServer
+
 @inject IApiReviewService ReviewService
+
 
 <div class="fixed inset-0 bg-gray-900 bg-opacity-50 flex items-center justify-center" @onclick="HandleBackgroundClick">
     <div class="bg-white p-8 rounded shadow-lg w-1/3 h-auto" @onclick:stopPropagation="true" @onclick:preventDefault="true">
-        <h2 class="text-xl font-bold mb-4">Add a Review</h2>
+        <h2 class="text-xl font-bold mb-4">Edit Review</h2>
 
         <textarea @bind="ReviewContent" class="w-full h-64 p-2 border outline-none rounded mb-3 resize-none !important" placeholder="Write your thoughts here..."></textarea>
         @if (IsContentEmpty)
         {
             <p class="text-gray-500 text-sm mb-3">Review content cannot be empty</p>
         }
-
 @*         <div class="mb-4 p-4 bg-gray-100 rounded-lg shadow-md">
             <label for="rating" class="block mb-2 font-bold text-lg text-gray-700">
                 Rating: <span class="text-purple-500">@Rating</span>
@@ -29,6 +31,7 @@
         </button>
     </div>
 </div>
+
 
 @code {
     [Parameter]

--- a/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Components/Reviews/WriteReviewPopup.razor
+++ b/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Components/Reviews/WriteReviewPopup.razor
@@ -70,7 +70,7 @@
         }
     }
 
-    private int _rating;
+    private int _rating = 5;
 
     private bool IsContentEmpty { get; set; } = false;
 

--- a/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Services/ApiIdentity/ApiIdentityService.cs
+++ b/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Services/ApiIdentity/ApiIdentityService.cs
@@ -1,9 +1,6 @@
-using CommonLibrary.DataClasses.ReviewModel;
 using SpreeviewAPI.Wrappers;
 
 namespace SpreeviewFrontend.Services.ApiIdentity;
-
-
 
 public class ApiIdentityService : IApiIdentityService
 {
@@ -19,7 +16,7 @@ public class ApiIdentityService : IApiIdentityService
         try
         {
 			var response = await _httpClient.GetFromJsonAsync<int>($"/identity");
-            Console.WriteLine("User Id");
+            Console.WriteLine("User ID:");
             Console.WriteLine(response);
 			if (response != null)
 			{
@@ -28,9 +25,26 @@ public class ApiIdentityService : IApiIdentityService
         }
         catch (Exception e)
         {
-            Console.WriteLine("failed");
-            Console.WriteLine(e.Message);
+            Console.WriteLine($"ERROR: failed to get User ID: {e}");
         }
 		return new ServiceObjectResponse<int>() { Type = ServiceResponseType.Failure };
 	}
+
+    public async Task<ServiceObjectResponse<string>> GetUserNameByIdAsync(int userId)
+    {
+        try
+        {
+            var response = await _httpClient.GetAsync($"identity/{userId}");
+            if (response != null)
+            {
+                var content = await response.Content.ReadAsStringAsync();
+                return new ServiceObjectResponse<string>() { Type = ServiceResponseType.Success, Value = content };
+            }
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"ERROR: failed to get User Name by ID: {e}");
+        }
+        return new ServiceObjectResponse<string>() { Type = ServiceResponseType.Failure, Value = "" };
+    }
 }

--- a/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Services/ApiIdentity/IApiIdentityService.cs
+++ b/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Services/ApiIdentity/IApiIdentityService.cs
@@ -5,4 +5,5 @@ namespace SpreeviewFrontend.Services.ApiIdentity;
 public interface IApiIdentityService
 {
     Task<ServiceObjectResponse<int>> GetUserIdAsync();
+    Task<ServiceObjectResponse<string>> GetUserNameByIdAsync(int userId);
 }

--- a/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Services/ApiReview/ApiReviewService.cs
+++ b/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Services/ApiReview/ApiReviewService.cs
@@ -1,5 +1,4 @@
 ﻿using CommonLibrary.DataClasses.ReviewModel;
-using CommonLibrary.DataClasses.SeriesModel;
 using SpreeviewAPI.Wrappers;
 
 namespace SpreeviewFrontend.Services.ApiReview;
@@ -77,7 +76,8 @@ public class ApiReviewService : IApiReviewService
 
             if (response != null)
             {
-                return new ServiceObjectResponse<List<ReviewGetDTO>>() { Type = ServiceResponseType.Success, Value = response };
+                var orderedResponse = response.OrderByDescending(r => r.DateAdded).ToList();
+                return new ServiceObjectResponse<List<ReviewGetDTO>>() { Type = ServiceResponseType.Success, Value = orderedResponse };
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
- Add GetUserNameById() endpoint and also edit reviews and comments, in order to display (placeholder) usernames instead of "User x" on all reviews and comments.
- Fix Profile bug where an exception would be thrown if no reviews and/or comments were found.
- Order Series page reviews to show the newest-added reviews first.
- Edit reviews and comments to italicise contents, to discern it from their associated metadata.
- Changed default rating while adding reviews to 5 (instead of 0, which is outside our allowed ratings).
- Fixed text heading when editing reviews.