### PR TITLE
fix: Fix chat login redirect exception

### DIFF
--- a/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Components/Pages/Chat.razor
+++ b/Spreeview/SpreeviewFrontend/SpreeviewFrontend/Components/Pages/Chat.razor
@@ -80,6 +80,7 @@
         if (authState.User.Identity is not { IsAuthenticated: true })
         {
             NavigateToLogin();
+            return;
         }
 
         // Setup a new HubConnection to chat hub


### PR DESCRIPTION
Chat wasn't returning the OnInitializedAsync method on failed authentication